### PR TITLE
Remove login gate and add manual tab open step

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ transcript is required.
 The popup now lets you customise the scoring and rewriting prompts. Choose the
 desired ChatGPT model manually within the ChatGPT tab—the extension simply sends
 your prompts to whatever model is active.
-Before starting, ensure you are logged into both sites. The popup checks for cookies and refuses to run if either account is missing.
-Once processing completes the extension automatically closes the hidden YouTube and ChatGPT tabs.
+Use the new **Open tabs** button to launch hidden YouTube and ChatGPT tabs. Once
+they load, click **Start** to begin processing. The extension no longer blocks
+you if login cookies are missing. When finished it automatically closes the
+hidden tabs.
 
 ## Development status
 

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -22,7 +22,8 @@
       <textarea id="rewritePrompt" rows="4" style="width:100%"></textarea>
     </label>
   </div>
-  <button id="start">Start</button>
+  <button id="openTabs">Step 1: Open tabs</button>
+  <button id="start">Step 2: Start</button>
   <button id="stop">Stop</button>
   <button id="open">Open results</button>
   <div style="margin-top:4px"><progress id="progress" value="0" max="100" style="width:100%"></progress></div>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -64,11 +64,11 @@ async function checkLogin() {
   return yt.length > 0 && gpt.length > 0;
 }
 
+document.getElementById('openTabs').addEventListener('click', () => {
+  chrome.runtime.sendMessage({ cmd: 'openTabs' });
+});
+
 document.getElementById('start').addEventListener('click', async () => {
-  if (!(await checkLogin())) {
-    statusEl.textContent = 'Please log into YouTube and ChatGPT first';
-    return;
-  }
   const opts = {
     count: Number(countEl.value),
     scorePrompt: scoreEl.value || DEFAULT_SCORE_PROMPT,


### PR DESCRIPTION
## Summary
- drop required login check before starting processing
- add new *Open tabs* step to launch YouTube and ChatGPT tabs
- update popup UI for two‑step workflow
- document the new behaviour in the README

## Testing
- `python -m py_compile server.py package.py`

------
https://chatgpt.com/codex/tasks/task_e_68655ba147f883308ff2831b3795079e