### PR TITLE
Improve update function for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ python server.py [--whisper-model medium] [--whisper-language ja]
 
 Windows users can run `run_app.bat` for a small menu that installs or
 uninstalls the requirements. The menu also includes an option to update the
-repository from GitHub before launching the server. A separate
-`package.py` script creates a distributable zip containing the server
+repository from GitHub before launching the server. This works only when the
+project is a Git clone; the packaged zip does not contain the `.git` folder.
+A separate `package.py` script creates a distributable zip containing the server
 and Chrome extension:
 
 ```bash

--- a/run_app.bat
+++ b/run_app.bat
@@ -37,7 +37,11 @@ if "%choice%"=="5" (
     goto menu
 )
 if "%choice%"=="6" (
-    git -C "%~dp0." pull
+    if exist "%~dp0\.git" (
+        git -C "%~dp0." pull
+    ) else (
+        echo Git repository not found. Please clone using git to enable updates.
+    )
     pause
     goto menu
 )


### PR DESCRIPTION
## Summary
- stop run_app.bat update option failing when repository isn't a Git clone
- clarify README that update requires cloning the repo via Git

## Testing
- `python -m py_compile server.py package.py`

------
https://chatgpt.com/codex/tasks/task_e_686567440ad88330b29dff33142f038c