### PR TITLE
Add support for new ChatGPT domain

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -115,7 +115,7 @@ function waitTabComplete(tabId) {
 async function openTabs() {
   cleanupTabs();
   ytTabId = await openTab('https://www.youtube.com');
-  gptTabId = await openTab('https://chat.openai.com');
+  gptTabId = await openTab('https://chatgpt.com');
 }
 
 async function collectLinks(tabId, count) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -13,6 +13,7 @@
   "host_permissions": [
     "http://localhost:5001/*",
     "https://www.youtube.com/*",
-    "https://chat.openai.com/*"
+    "https://chat.openai.com/*",
+    "https://chatgpt.com/*"
   ]
 }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -67,9 +67,10 @@ const DEFAULT_REWRITE_PROMPT = `以原作者视角，忠实呈现视频中的观
 async function checkLogin() {
   const yt = await chrome.cookies.getAll({ url: 'https://www.youtube.com' });
   const gpt = await chrome.cookies.getAll({ url: 'https://chat.openai.com' });
+  const gptAlt = await chrome.cookies.getAll({ url: 'https://chatgpt.com' });
   ytStatusEl.textContent = yt.length ? 'YouTube: logged in' : '';
-  gptStatusEl.textContent = gpt.length ? 'ChatGPT: logged in' : '';
-  return yt.length > 0 && gpt.length > 0;
+  gptStatusEl.textContent = (gpt.length || gptAlt.length) ? 'ChatGPT: logged in' : '';
+  return yt.length > 0 && (gpt.length > 0 || gptAlt.length > 0);
 }
 
 document.getElementById('openTabs').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- permit `chatgpt.com` in extension host permissions
- check cookies on new domain
- open ChatGPT tabs using `chatgpt.com`

## Testing
- `python -m py_compile server.py package.py`


------
https://chatgpt.com/codex/tasks/task_e_6865855404c0833082affa9166cebbdf