### PR TITLE
Make processing popups focused

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ transcript is required.
 The popup now lets you customise the scoring and rewriting prompts. Choose the
 desired ChatGPT model manually within the ChatGPT tab—the extension simply sends
 your prompts to whatever model is active.
-Use the new **Open tabs** button to launch hidden YouTube and ChatGPT tabs. Once
-they load, click **Start** to begin processing. The extension no longer blocks
-you if login cookies are missing. When finished it automatically closes the
-hidden tabs.
+Use the new **Open tabs** button to launch focused YouTube and ChatGPT popup
+windows. Once they load, click **Start** to begin processing. The extension no
+longer blocks you if login cookies are missing. When finished it automatically
+closes the popups.
 
 ## Development status
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -12,7 +12,7 @@ The new application consists of a local helper server and a browser extension.
 
 ### Browser Extension
 - Provides a control panel where the user can start or stop analysis, choose the number of videos to process and configure prompts.
-- Opens two hidden tabs: one for YouTube and one for ChatGPT. Both tabs share the user's logged-in cookies.
+- Opens two focused popup windows: one for YouTube and one for ChatGPT. Both windows share the user's logged-in cookies.
 - Collects video links from the YouTube feed by scrolling until the desired number of items is gathered, excluding Shorts, ads and other irrelevant entries.
 
 ### Local Helper Server
@@ -21,8 +21,8 @@ The new application consists of a local helper server and a browser extension.
 
 ### Processing Steps
 1. The extension gathers video links and attempts to download official subtitles. If none are available it requests audio transcription from the local server.
-2. Each transcript is processed inside the extension using a hidden ChatGPT tab—first for scoring, then for rewriting as an article.
-3. Results are stored in extension storage and presented on an internal page sorted by total score. Users can like or dislike a video which triggers optional watch-through actions in the hidden YouTube tab.
+2. Each transcript is processed inside the extension using the focused ChatGPT popup—first for scoring, then for rewriting as an article.
+3. Results are stored in extension storage and presented on an internal page sorted by total score. Users can like or dislike a video which triggers optional watch-through actions in the focused YouTube popup.
 
 ## Default Prompts
 ### Scoring

--- a/extension/background.js
+++ b/extension/background.js
@@ -93,8 +93,8 @@ function openPopup(url) {
     chrome.windows.create({
       url,
       type: 'popup',
-      focused: false,
-      state: 'minimized'
+      focused: true,
+      state: 'normal'
     }, win => {
       resolve({ windowId: win.id, tabId: win.tabs[0].id });
     });


### PR DESCRIPTION
## Summary
- keep YouTube and ChatGPT popups visible so pages load properly
- update README and overview docs to match new behaviour

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68659eccf86c8330b0a95adb9d59f538