### PR TITLE
Improve extension styling

### DIFF
--- a/extension/article.html
+++ b/extension/article.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Article</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <h1 id="title"></h1>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -2,10 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <style>
-    body { min-width: 200px; font-family: sans-serif; }
-    button { margin: 4px; }
-  </style>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <h4>Reimagine Doomscrolling</h4>
@@ -14,20 +11,20 @@
   </div>
   <div>
     <label>Scoring prompt<br>
-      <textarea id="scorePrompt" rows="6" style="width:100%"></textarea>
+      <textarea id="scorePrompt" rows="6"></textarea>
     </label>
   </div>
   <div>
     <label>Rewrite prompt<br>
-      <textarea id="rewritePrompt" rows="4" style="width:100%"></textarea>
+      <textarea id="rewritePrompt" rows="4"></textarea>
     </label>
   </div>
   <button id="openTabs">Step 1: Open tabs</button>
   <button id="start">Step 2: Start</button>
   <button id="stop">Stop</button>
   <button id="open">Open results</button>
-  <div style="margin-top:4px"><progress id="progress" value="0" max="100" style="width:100%"></progress></div>
-  <pre id="log" style="height:150px; overflow-y:auto; background:#f0f0f0; padding:4px"></pre>
+  <div style="margin-top:4px"><progress id="progress" value="0" max="100"></progress></div>
+  <pre id="log"></pre>
   <div id="status" style="display:none"></div>
   <div id="ytStatus"></div>
   <div id="gptStatus"></div>

--- a/extension/results.html
+++ b/extension/results.html
@@ -3,10 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Video Articles</title>
-  <style>
-    table {border-collapse: collapse; width: 100%;}
-    th, td {border: 1px solid #ccc; padding: 4px;}
-  </style>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <h1>Processed Videos</h1>

--- a/extension/style.css
+++ b/extension/style.css
@@ -1,0 +1,67 @@
+body {
+  font-family: 'Segoe UI', Tahoma, sans-serif;
+  margin: 0;
+  padding: 12px;
+  background: #fafafa;
+  color: #333;
+  min-width: 200px;
+}
+
+h1, h2, h3, h4 {
+  font-weight: 500;
+  margin-top: 0;
+}
+
+button {
+  margin: 4px 0;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  background: #222;
+  color: #fff;
+  cursor: pointer;
+  font-size: 14px;
+}
+button:hover {
+  background: #444;
+}
+
+textarea, input[type="number"], input[type="text"] {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  font-family: inherit;
+}
+
+progress {
+  width: 100%;
+}
+
+#log {
+  height: 150px;
+  overflow-y: auto;
+  background: #f0f0f0;
+  padding: 8px;
+  border-radius: 4px;
+}
+
+pre {
+  white-space: pre-wrap;
+  font-family: inherit;
+  background: #f0f0f0;
+  padding: 8px;
+  border-radius: 4px;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 6px;
+  text-align: left;
+}


### PR DESCRIPTION
## Summary
- add a shared stylesheet for a modern look
- reference the stylesheet from extension pages
- remove inline styles to keep markup clean

## Testing
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_6865b0864a9c8330acbb3875d3e1da41