### PR TITLE
Enable ChatGPT UI integration

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -207,35 +207,10 @@ async function runChatPrompt(prompt) {
       if (window.location.pathname === '/' && maybeNewChatBtn) {
         maybeNewChatBtn.click();
       }
-
-      function sendPrompt(text) {
-        const box = document.querySelector('textarea[name="prompt-textarea"]');
-        if (!box) return;
-        box.value = text;
-        box.dispatchEvent(new Event('input', {bubbles: true}));
-        box.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter', bubbles: true}));
+      if (window.sendPrompt) {
+        return await window.sendPrompt(p);
       }
-
-      function waitForAssistantReply() {
-        return new Promise(resolve => {
-          const thread = document.getElementById('thread-bottom-container') || document.body;
-          const pickLast = () =>
-            thread.querySelectorAll('[data-message-author-role="assistant"]').pop();
-          const ready = pickLast();
-          if (ready) return resolve(ready.innerText);
-          const mo = new MutationObserver(() => {
-            const node = pickLast();
-            if (node && node.innerText.trim()) {
-              mo.disconnect();
-              resolve(node.innerText);
-            }
-          });
-          mo.observe(thread, { childList: true, subtree: true });
-        });
-      }
-
-      sendPrompt(p);
-      return await waitForAssistantReply();
+      return '';
     },
     args: [prompt]
   });

--- a/extension/chatgpt.js
+++ b/extension/chatgpt.js
@@ -1,0 +1,91 @@
+/* Content script for interacting with ChatGPT web UI */
+
+// Utility: wait for an element that exists now or in the future
+function waitFor(selector, root = document, timeout = 30000) {
+  return new Promise((resolve, reject) => {
+    const el = root.querySelector(selector);
+    if (el) return resolve(el);
+
+    const obs = new MutationObserver(() => {
+      const node = root.querySelector(selector);
+      if (node) {
+        obs.disconnect();
+        clearTimeout(tid);
+        resolve(node);
+      }
+    });
+    obs.observe(root, { childList: true, subtree: true });
+
+    const tid = setTimeout(() => {
+      obs.disconnect();
+      reject(new Error(`Timeout waiting for ${selector}`));
+    }, timeout);
+  });
+}
+
+// Find the composer elements
+async function getComposer() {
+  const textarea = await waitFor('textarea[name="prompt-textarea"]');
+  return {
+    textarea,
+    sendButton() {
+      return textarea.closest('form')?.querySelector('button[aria-label^="Send"]');
+    }
+  };
+}
+
+// Simulate pressing Enter
+function dispatchEnter(node) {
+  const evtInit = { bubbles: true, cancelable: true, key: 'Enter', code: 'Enter' };
+  node.dispatchEvent(new KeyboardEvent('keydown', evtInit));
+  node.dispatchEvent(new KeyboardEvent('keyup', evtInit));
+}
+
+// Send a prompt and resolve with assistant reply text
+async function sendPromptInternal(promptText) {
+  const { textarea, sendButton } = await getComposer();
+
+  textarea.value = promptText;
+  textarea.dispatchEvent(new InputEvent('input', { bubbles: true }));
+
+  const btn = sendButton();
+  if (btn) {
+    btn.click();
+  } else {
+    dispatchEnter(textarea);
+  }
+
+  const thread = await waitFor('#thread');
+  const existingIds = new Set(
+    Array.from(thread.querySelectorAll('[data-message-author-role="assistant"]'))
+         .map(n => n.getAttribute('data-message-id'))
+  );
+
+  return new Promise((resolve, reject) => {
+    const obs = new MutationObserver(muts => {
+      for (const m of muts) {
+        for (const n of m.addedNodes) {
+          if (
+            n.nodeType === 1 &&
+            n.matches?.('[data-message-author-role="assistant"]') &&
+            !existingIds.has(n.getAttribute('data-message-id'))
+          ) {
+            obs.disconnect();
+            const text = n.innerText.trim();
+            resolve(text);
+            return;
+          }
+        }
+      }
+    });
+    obs.observe(thread, { childList: true, subtree: true });
+
+    setTimeout(() => {
+      obs.disconnect();
+      reject(new Error('No assistant reply observed'));
+    }, 120000);
+  });
+}
+
+// expose globally for background script
+window.sendPrompt = sendPromptInternal;

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,6 +4,13 @@
   "version": "0.1",
   "description": "Collect and analyse YouTube feed videos",
   "permissions": ["tabs", "windows", "storage", "scripting", "cookies"],
+  "content_scripts": [
+    {
+      "matches": ["https://chatgpt.com/*", "https://chat.openai.com/*"],
+      "js": ["chatgpt.js"],
+      "run_at": "document_idle"
+    }
+  ],
   "background": {
     "service_worker": "background.js"
   },


### PR DESCRIPTION
## Summary
- add a content script that sends prompts through the ChatGPT web UI
- register the script in the extension manifest
- call the exposed `sendPrompt` helper from the background script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865b4058740833087fe526efe36918d