### PR TITLE
Fix extension manifest shortcut

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -26,7 +26,7 @@
   "commands": {
     "stop-processing": {
       "suggested_key": {
-        "default": "Ctrl+Alt+S"
+        "default": "Alt+Shift+S"
       },
       "description": "Stop processing and shutdown server"
     }


### PR DESCRIPTION
## Summary
- change command shortcut from `Ctrl+Alt+S` to `Alt+Shift+S`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6866aae0077c8330830574b9bbfcbefb