### PR TITLE
Fix pyautogui click coordinates

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -287,7 +287,10 @@ async function runChatPrompt(prompt) {
       function pos(el) {
         if (!el) return null;
         const r = el.getBoundingClientRect();
-        return { x: window.screenX + r.left + r.width / 2, y: window.screenY + r.top + r.height / 2 };
+        return {
+          x: Math.round(window.screenX + r.left + r.width / 2),
+          y: Math.round(window.screenY + r.top + r.height / 2)
+        };
       }
       return { newChat: window.location.pathname === '/' ? pos(newBtn) : null, composer: pos(composer), send: pos(send) };
     }

--- a/server.py
+++ b/server.py
@@ -132,7 +132,13 @@ def api_click() -> jsonify:
     y = data.get("y")
     if x is None or y is None:
         return jsonify({"error": "missing coordinates"}), 400
-    pyautogui.click(x, y)
+    try:
+        x = int(round(float(x)))
+        y = int(round(float(y)))
+    except (ValueError, TypeError):
+        return jsonify({"error": "invalid coordinates"}), 400
+    pyautogui.moveTo(x, y)
+    pyautogui.click()
     time.sleep(0.1)
     return jsonify({"status": "ok"})
 


### PR DESCRIPTION
## Summary
- round screen coordinates in the extension before sending them to the server
- validate and normalize coordinates in `/api/click`

## Testing
- `python -m py_compile server.py`
- `python -m py_compile $(git ls-files '*.py')`
- `node --check extension/background.js`


------
https://chatgpt.com/codex/tasks/task_e_6866b7c65800833093ba5ab10397fa8a