### PR TITLE
Make core integration points explicit placeholders and make pipeline fail fast

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ For planning workflow on Windows, you can also run `manage_dev_plan.bat` directl
 Use `run_app.bat` option 5, or run:
 - `pytest backend/tests -q`
 - `npm test` in `frontend/`
+
+## Required integrations currently left as placeholders
+- `backend/app/services/youtube.py::discover_videos`
+- `backend/app/services/transcript.py::fetch_transcript`
+- `backend/app/services/transcript.py::transcribe_audio_locally`
+- `backend/app/services/generation.py::generate_article`
+
+These functions now intentionally raise `NotImplementedError` so unfinished integrations fail fast instead of producing mock data.
+

--- a/backend/app/services/generation.py
+++ b/backend/app/services/generation.py
@@ -12,6 +12,8 @@ def render_prompt(template: str, transcript: str, mode: str) -> str:
     return template.replace("{{transcript}}", transcript).replace("{{mode}}", mode)
 
 
-def generate_article(transcript: str, prompt: str, cfg: ProviderConfig) -> str:
-    header = f"# {cfg.provider}:{cfg.model}\n"
-    return header + prompt[:200] + "\n\n" + transcript[:1500]
+def generate_article(_transcript: str, _prompt: str, _cfg: ProviderConfig) -> str:
+    raise NotImplementedError(
+        "generate_article is a required integration point and still a placeholder. "
+        "Implement provider API calls (OpenAI/LM Studio/etc.) before publishing articles."
+    )

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -10,14 +10,22 @@ from app.services.youtube import discover_videos, evaluate_video_policy
 
 def refresh_source(db, source_id: int):
     source = db.get(Source, source_id)
-    videos = discover_videos(source)
+    try:
+        videos = discover_videos(source)
+    except NotImplementedError as exc:
+        db.add(Job(type="refresh_source", status="failed", source_id=source_id, error=str(exc)))
+        source.failure_count += 1
+        source.last_scan_at = datetime.utcnow()
+        db.commit()
+        return
+
     for raw in videos:
         allowed, reason = evaluate_video_policy(raw, source)
         if not allowed:
             item = VideoItem(source_id=source_id, video_id=raw["video_id"], url=raw["url"], title=raw["title"], status=ItemStatus.skipped_by_policy, status_message=reason)
             db.merge(item)
             continue
-        exists = db.execute(select(VideoItem).where(VideoItem.source_id == source_id, VideoItem.video_id == raw["video_id"])) .scalar_one_or_none()
+        exists = db.execute(select(VideoItem).where(VideoItem.source_id == source_id, VideoItem.video_id == raw["video_id"])).scalar_one_or_none()
         if exists:
             continue
         item = VideoItem(source_id=source_id, video_id=raw["video_id"], url=raw["url"], title=raw["title"], status=ItemStatus.queued)
@@ -31,33 +39,46 @@ def refresh_source(db, source_id: int):
 
 def process_video_item(db, item_id: int):
     item = db.get(VideoItem, item_id)
-    item.status = ItemStatus.transcript_searching
-    text, source_kind = fetch_transcript(item.url, ["en"])
-    if not text and should_fallback_to_transcription("transcript_first", False, True):
-        item.status = ItemStatus.transcription_started
-        text = transcribe_audio_locally(item.url)
-        item.status = ItemStatus.transcription_completed
-    else:
-        item.status = ItemStatus.transcript_found
-    transcript = db.execute(select(Transcript).where(Transcript.video_item_id == item.id)).scalar_one_or_none()
-    if transcript:
-        transcript.text = text
-        transcript.source = source_kind
-    else:
-        db.add(Transcript(video_item_id=item.id, text=text, source=source_kind))
-    item.status = ItemStatus.generation_started
-    prompt = render_prompt("Convert to {{mode}} article\n{{transcript}}", text, "detailed")
-    body = generate_article(text, prompt, ProviderConfig(provider="openai", model="gpt-4.1-mini"))
-    article = db.execute(select(Article).where(Article.video_item_id == item.id)).scalar_one_or_none()
-    if not article:
-        article = Article(video_item_id=item.id, title=item.title)
-        db.add(article)
-        db.flush()
-        version_num = 1
-    else:
-        version_num = article.latest_version + 1
-        article.latest_version = version_num
-    db.add(ArticleVersion(article_id=article.id, version=version_num, mode="detailed", prompt_snapshot=prompt, body=body))
-    item.status = ItemStatus.published
-    db.add(Job(type="process_item", status="done", video_item_id=item.id, source_id=item.source_id))
+
+    try:
+        item.status = ItemStatus.transcript_searching
+        text, source_kind = fetch_transcript(item.url, ["en"])
+
+        if not text and should_fallback_to_transcription("transcript_first", False, True):
+            item.status = ItemStatus.transcription_started
+            text = transcribe_audio_locally(item.url)
+            source_kind = "local_transcription"
+            item.status = ItemStatus.transcription_completed
+        else:
+            item.status = ItemStatus.transcript_found
+
+        transcript = db.execute(select(Transcript).where(Transcript.video_item_id == item.id)).scalar_one_or_none()
+        if transcript:
+            transcript.text = text
+            transcript.source = source_kind
+        else:
+            db.add(Transcript(video_item_id=item.id, text=text, source=source_kind))
+
+        item.status = ItemStatus.generation_started
+        prompt = render_prompt("Convert to {{mode}} article\n{{transcript}}", text, "detailed")
+        body = generate_article(text, prompt, ProviderConfig(provider="openai", model="gpt-4.1-mini"))
+
+        article = db.execute(select(Article).where(Article.video_item_id == item.id)).scalar_one_or_none()
+        if not article:
+            article = Article(video_item_id=item.id, title=item.title)
+            db.add(article)
+            db.flush()
+            version_num = 1
+        else:
+            version_num = article.latest_version + 1
+            article.latest_version = version_num
+
+        db.add(ArticleVersion(article_id=article.id, version=version_num, mode="detailed", prompt_snapshot=prompt, body=body))
+        item.status = ItemStatus.published
+        db.add(Job(type="process_item", status="done", video_item_id=item.id, source_id=item.source_id))
+    except NotImplementedError as exc:
+        item.status = ItemStatus.failed
+        item.status_message = str(exc)
+        db.add(Job(type="process_item", status="failed", video_item_id=item.id, source_id=item.source_id, error=str(exc)))
+
     db.commit()

--- a/backend/app/services/transcript.py
+++ b/backend/app/services/transcript.py
@@ -12,8 +12,14 @@ def should_fallback_to_transcription(strategy: str, transcript_found: bool, fall
 
 
 def fetch_transcript(_video_url: str, _languages: list[str]) -> tuple[str, str]:
-    return "Sample transcript text", "manual"
+    raise NotImplementedError(
+        "fetch_transcript is a required integration point and still a placeholder. "
+        "Implement transcript retrieval from your selected provider."
+    )
 
 
 def transcribe_audio_locally(_video_url: str) -> str:
-    return "Local transcription text"
+    raise NotImplementedError(
+        "transcribe_audio_locally is a required integration point and still a placeholder. "
+        "Implement local transcription wiring before enabling fallback."
+    )

--- a/backend/app/services/youtube.py
+++ b/backend/app/services/youtube.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import urlparse
 
 
 def normalize_source_url(url: str) -> str:
@@ -29,16 +29,7 @@ def evaluate_video_policy(video: dict, source) -> tuple[bool, str]:
 
 
 def discover_videos(_source) -> list[dict]:
-    now = datetime.utcnow()
-    return [
-        {
-            "video_id": f"mock-{i}",
-            "url": f"https://youtube.com/watch?v=mock-{i}",
-            "title": f"Mock Video {i}",
-            "duration": 300,
-            "published_at": now,
-            "thumbnail": "",
-            "is_live": False,
-        }
-        for i in range(1, _source.max_videos + 1)
-    ]
+    raise NotImplementedError(
+        "discover_videos is a required integration point and still a placeholder. "
+        "Implement real YouTube channel discovery before using refresh flows."
+    )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,3 +4,6 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
+
+# Keep integration tests deterministic by starting from a clean local DB file.
+Path('test.db').unlink(missing_ok=True)

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -3,7 +3,7 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
-def test_settings_source_refresh_library_flow():
+def test_settings_source_refresh_handles_placeholders_gracefully():
     with TestClient(app) as client:
         r = client.put('/api/settings', json={'provider': 'openai'})
         assert r.status_code == 200
@@ -17,12 +17,8 @@ def test_settings_source_refresh_library_flow():
 
         lib = client.get('/api/library')
         assert lib.status_code == 200
-        assert len(lib.json()) >= 1
+        assert lib.json() == []
 
-        aid = lib.json()[0]['article_id']
-        regen = client.post(f'/api/articles/{aid}/regenerate')
-        assert regen.status_code == 200
-
-        detail = client.get(f'/api/articles/{aid}')
-        assert detail.status_code == 200
-        assert len(detail.json()['versions']) >= 1
+        jobs = client.get('/api/jobs')
+        assert jobs.status_code == 200
+        assert any(job['status'] == 'failed' and job['type'] == 'refresh_source' for job in jobs.json())

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from app.services.generation import ProviderConfig, generate_article, render_prompt
 from app.services.transcript import should_fallback_to_transcription
 from app.services.youtube import evaluate_video_policy, normalize_source_url
@@ -20,7 +22,7 @@ def test_fallback_logic():
     assert not should_fallback_to_transcription('disable_fallback', False, True)
 
 
-def test_prompt_and_provider():
+def test_prompt_and_generation_placeholder():
     prompt = render_prompt('Mode={{mode}}\n{{transcript}}', 'abc', 'study')
-    out = generate_article('abc', prompt, ProviderConfig(provider='openai', model='x'))
-    assert 'openai:x' in out
+    with pytest.raises(NotImplementedError):
+        generate_article('abc', prompt, ProviderConfig(provider='openai', model='x'))


### PR DESCRIPTION
### Motivation
- The code contained mock/placeholder returns that produced fake successful outputs and hid required integration work. 
- The intent is to make missing integrations explicit so runs fail fast and surface required work instead of returning fabricated data.

### Description
- Replaced mock implementations with explicit `NotImplementedError` placeholders in `backend/app/services/youtube.py::discover_videos`, `backend/app/services/transcript.py::fetch_transcript`, `backend/app/services/transcript.py::transcribe_audio_locally`, and `backend/app/services/generation.py::generate_article` so these functions are clearly required integration points. 
- Updated the pipeline in `backend/app/services/pipeline.py` to catch `NotImplementedError` and record failed `Job` entries and `VideoItem` failure state instead of proceeding with fake content. 
- Adjusted tests to assert placeholder-aware behavior and added deterministic test DB handling by removing `test.db` at test startup in `backend/tests/conftest.py`. 
- Documented the remaining required integrations in `README.md` so maintainers can see what must be implemented.

### Testing
- Ran `pytest backend/tests -q` and all backend tests passed (`5 passed`) with expected deprecation warnings. 
- Unit tests updated to expect `NotImplementedError` from `generate_article` and integration test updated to assert that refresh flow produces a failed `refresh_source` job and leaves the library empty, and these tests succeeded under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95b5f7aa88331a3bc7fd2f805408a)