### PR TITLE
Expose default settings, improve diagnostics, and honor configured yt-dlp path

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -9,6 +9,13 @@ from app.services.pipeline import refresh_source
 from app.services.youtube import normalize_source_url
 
 router = APIRouter()
+DEFAULT_APP_SETTINGS = {
+    "ffmpeg_path": "",
+    "yt_dlp_path": "",
+    "openai_api_key": "",
+    "openai_base_url": "https://api.openai.com/v1",
+    "lmstudio_base_url": "http://localhost:1234/v1",
+}
 
 
 @router.get('/health')
@@ -19,7 +26,8 @@ def health():
 @router.get('/settings')
 def get_settings(db: Session = Depends(get_db)):
     rows = db.execute(select(AppSetting)).scalars().all()
-    return {r.key: r.value for r in rows}
+    saved = {r.key: r.value for r in rows}
+    return {**DEFAULT_APP_SETTINGS, **saved}
 
 
 @router.put('/settings')
@@ -134,9 +142,30 @@ def create_collection(body: dict, db: Session = Depends(get_db)):
 @router.get('/diagnostics')
 def diagnostics():
     import shutil
+    from app.db.session import SessionLocal
+
+    ffmpeg_detected = False
+    yt_dlp_detected = False
+    ffmpeg_command = "ffmpeg"
+    yt_dlp_command = "yt-dlp"
+
+    db = SessionLocal()
+    try:
+        rows = db.execute(select(AppSetting).where(AppSetting.key.in_(["ffmpeg_path", "yt_dlp_path"]))).scalars().all()
+        settings_map = {row.key: row.value.strip() for row in rows}
+        ffmpeg_command = settings_map.get("ffmpeg_path") or ffmpeg_command
+        yt_dlp_command = settings_map.get("yt_dlp_path") or yt_dlp_command
+    finally:
+        db.close()
+
+    ffmpeg_detected = bool(shutil.which(ffmpeg_command) or (ffmpeg_command and shutil.which("ffmpeg")))
+    yt_dlp_detected = bool(shutil.which(yt_dlp_command) or (yt_dlp_command and shutil.which("yt-dlp")))
+
     return {
-        'ffmpeg': bool(shutil.which('ffmpeg')),
-        'yt_dlp': bool(shutil.which('yt-dlp')),
+        'ffmpeg': ffmpeg_detected,
+        'ffmpeg_command': ffmpeg_command,
+        'yt_dlp': yt_dlp_detected,
+        'yt_dlp_command': yt_dlp_command,
         'faster_whisper': True,
         'db': True,
         'queue': True,

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from sqlalchemy import select
 
-from app.models.entities import Article, ArticleVersion, ItemStatus, Job, Source, Transcript, VideoItem
+from app.models.entities import AppSetting, Article, ArticleVersion, ItemStatus, Job, Source, Transcript, VideoItem
 from app.services.generation import ProviderConfig, generate_article, render_prompt
 from app.services.transcript import fetch_transcript, should_fallback_to_transcription, transcribe_audio_locally
 from app.services.youtube import discover_videos, evaluate_video_policy
@@ -46,7 +46,9 @@ def process_video_item(db, item_id: int):
 
         if not text and should_fallback_to_transcription("transcript_first", False, True):
             item.status = ItemStatus.transcription_started
-            text = transcribe_audio_locally(item.url)
+            yt_dlp_setting = db.execute(select(AppSetting).where(AppSetting.key == "yt_dlp_path")).scalar_one_or_none()
+            yt_dlp_command = yt_dlp_setting.value.strip() if yt_dlp_setting and yt_dlp_setting.value else "yt-dlp"
+            text = transcribe_audio_locally(item.url, yt_dlp_command=yt_dlp_command)
             source_kind = "local_transcription"
             item.status = ItemStatus.transcription_completed
         else:

--- a/backend/app/services/transcript.py
+++ b/backend/app/services/transcript.py
@@ -45,11 +45,11 @@ def fetch_transcript(video_url: str, languages: list[str]) -> tuple[str, str]:
     return text, "youtube_transcript"
 
 
-def transcribe_audio_locally(video_url: str) -> str:
+def transcribe_audio_locally(video_url: str, yt_dlp_command: str = "yt-dlp") -> str:
     with tempfile.TemporaryDirectory(prefix="reimagine_transcribe_") as temp_dir:
         audio_path = os.path.join(temp_dir, "audio.%(ext)s")
         cmd = [
-            "yt-dlp",
+            yt_dlp_command,
             "-f",
             "bestaudio/best",
             "-x",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -322,6 +322,16 @@ function Reader() {
 function Settings() {
   const queryClient = useQueryClient();
   const [draft, setDraft] = useState<Record<string, string>>({});
+  const settingsTemplate = useMemo(
+    () => ({
+      ffmpeg_path: '',
+      yt_dlp_path: '',
+      openai_api_key: '',
+      openai_base_url: 'https://api.openai.com/v1',
+      lmstudio_base_url: 'http://localhost:1234/v1',
+    }),
+    [],
+  );
   const settings = useQuery({ queryKey: ['settings'], queryFn: async () => (await api.get('/settings')).data as Record<string, string> });
 
   const save = useMutation({
@@ -329,11 +339,15 @@ function Settings() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['settings'] }),
   });
 
-  const merged = { ...(settings.data ?? {}), ...draft };
+  const merged = { ...settingsTemplate, ...(settings.data ?? {}), ...draft };
 
   return (
     <Page title='Settings'>
       <article className='card'>
+        <p className='muted'>
+          If diagnostics shows <code>ffmpeg: false</code>, set <code>ffmpeg_path</code> to your executable path (for example,
+          <code> C:\ffmpeg\bin\ffmpeg.exe</code>) and save.
+        </p>
         <div className='stack'>
           {Object.entries(merged).map(([k, v]) => (
             <label key={k}>


### PR DESCRIPTION
### Motivation
- Fresh installs returned an empty settings object which made the Settings page effectively blank and confusing to users.  
- Diagnostics reported `ffmpeg: false` without an obvious way to provide an executable path from the UI.  
- Local transcription always invoked `yt-dlp` directly, ignoring any configured path overrides.

### Description
- Add `DEFAULT_APP_SETTINGS` and merge it with stored rows in `GET /settings` so the Settings UI always shows core keys like `ffmpeg_path` and `yt_dlp_path`.  
- Enhance the diagnostics endpoint to read `ffmpeg_path` and `yt_dlp_path` from settings and return both detection booleans and the resolved commands (`ffmpeg_command`, `yt_dlp_command`).  
- Make `transcribe_audio_locally` accept a `yt_dlp_command` parameter and update the pipeline to read `yt_dlp_path` from the DB and pass it through during fallback transcription.  
- Update the frontend `Settings` screen to supply a settings template so fields are visible on a fresh DB and add a short hint for fixing `ffmpeg` detection via `ffmpeg_path`.

### Testing
- Ran backend unit tests with `pytest backend/tests -q` and all tests passed.  
- Built the frontend with `npm run build` in `frontend/` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9674371d8833199031d4fb35561fa)