### PR TITLE
Add scheduler controls, typed settings/sources, reading progress, job-item tracking, and pipeline hardening

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,12 +1,24 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
-from app.models.entities import AppSetting, Article, ArticleVersion, Collection, Job, LogEvent, Source, VideoItem
-from app.schemas.source import SourceCreate, SourceOut
-from app.services.pipeline import refresh_source
+from app.models.entities import (
+    AppSetting,
+    Article,
+    ArticleVersion,
+    Collection,
+    Job,
+    LogEvent,
+    ReadingProgress,
+    Source,
+    VideoItem,
+)
+from app.schemas.common import CollectionCreate, MarkReadPayload, ReadingProgressPayload, SettingsPatch
+from app.schemas.source import SourceCreate, SourceOut, SourcePatch
+from app.services.pipeline import process_video_item, refresh_source
 from app.services.youtube import normalize_source_url
+from app.workers.scheduler import scheduler_status
 
 router = APIRouter()
 DEFAULT_APP_SETTINGS = {
@@ -15,7 +27,16 @@ DEFAULT_APP_SETTINGS = {
     "openai_api_key": "",
     "openai_base_url": "https://api.openai.com/v1",
     "lmstudio_base_url": "http://localhost:1234/v1",
+    "scheduler_enabled": "true",
+    "scheduler_default_cadence_minutes": "60",
+    "scheduler_concurrency_cap": "2",
+    "generation_provider": "openai",
+    "generation_model": "gpt-4.1-mini",
+    "generation_mode": "detailed",
+    "global_prompt_template": "Convert to {{mode}} article\n{{transcript}}",
+    "transcript_languages": "en",
 }
+SECRET_KEYS = {"openai_api_key"}
 
 
 @router.get('/health')
@@ -27,12 +48,16 @@ def health():
 def get_settings(db: Session = Depends(get_db)):
     rows = db.execute(select(AppSetting)).scalars().all()
     saved = {r.key: r.value for r in rows}
-    return {**DEFAULT_APP_SETTINGS, **saved}
+    merged = {**DEFAULT_APP_SETTINGS, **saved}
+    for k in SECRET_KEYS:
+        if k in merged and merged[k]:
+            merged[k] = "***redacted***"
+    return merged
 
 
 @router.put('/settings')
-def put_settings(payload: dict, db: Session = Depends(get_db)):
-    for k, v in payload.items():
+def put_settings(payload: SettingsPatch, db: Session = Depends(get_db)):
+    for k, v in payload.model_dump(exclude_none=True).items():
         db.merge(AppSetting(key=k, value=str(v)))
     db.commit()
     return {"saved": True}
@@ -49,7 +74,18 @@ def create_source(body: SourceCreate, db: Session = Depends(get_db)):
         normalized = normalize_source_url(body.url)
     except ValueError as e:
         raise HTTPException(400, str(e))
-    src = Source(url=normalized, title=body.title or normalized, cadence_minutes=body.cadence_minutes, discovery_mode=body.discovery_mode, max_videos=body.max_videos)
+
+    existing = db.execute(select(Source).where(Source.url == normalized)).scalar_one_or_none()
+    if existing:
+        raise HTTPException(400, "source already exists")
+
+    src = Source(
+        url=normalized,
+        title=body.title or normalized,
+        cadence_minutes=body.cadence_minutes,
+        discovery_mode=body.discovery_mode,
+        max_videos=body.max_videos,
+    )
     db.add(src)
     db.commit()
     db.refresh(src)
@@ -63,11 +99,11 @@ def refresh(source_id: int, db: Session = Depends(get_db)):
 
 
 @router.patch('/sources/{source_id}')
-def patch_source(source_id: int, body: dict, db: Session = Depends(get_db)):
+def patch_source(source_id: int, body: SourcePatch, db: Session = Depends(get_db)):
     src = db.get(Source, source_id)
     if not src:
         raise HTTPException(404)
-    for key, value in body.items():
+    for key, value in body.model_dump(exclude_none=True).items():
         if hasattr(src, key):
             setattr(src, key, value)
     db.commit()
@@ -79,26 +115,89 @@ def list_jobs(db: Session = Depends(get_db)):
     return db.execute(select(Job).order_by(Job.created_at.desc())).scalars().all()
 
 
+@router.get('/jobs/{job_id}')
+def get_job(job_id: int, db: Session = Depends(get_db)):
+    job = db.get(Job, job_id)
+    if not job:
+        raise HTTPException(404)
+    return job
+
+
 @router.post('/jobs/{job_id}/retry')
 def retry_job(job_id: int, db: Session = Depends(get_db)):
     job = db.get(Job, job_id)
     if not job:
         raise HTTPException(404)
     job.status = 'retry_pending'
+    if job.video_item_id:
+        process_video_item(db, job.video_item_id)
     db.commit()
     return {"retried": True}
 
 
+@router.get('/items/{item_id}')
+def item_detail(item_id: int, db: Session = Depends(get_db)):
+    item = db.get(VideoItem, item_id)
+    if not item:
+        raise HTTPException(404)
+    return item
+
+
+@router.get('/transcripts/{item_id}')
+def transcript_detail(item_id: int, db: Session = Depends(get_db)):
+    from app.models.entities import Transcript
+
+    tr = db.execute(select(Transcript).where(Transcript.video_item_id == item_id)).scalar_one_or_none()
+    if not tr:
+        raise HTTPException(404)
+    return tr
+
+
+@router.post('/transcripts/{item_id}/retry')
+def transcript_retry(item_id: int, db: Session = Depends(get_db)):
+    process_video_item(db, item_id)
+    return {"retried": True}
+
+
 @router.get('/library')
-def library(q: str = '', db: Session = Depends(get_db)):
-    stmt = select(Article, VideoItem).join(VideoItem, Article.video_item_id == VideoItem.id)
+def library(
+    q: str = '',
+    source: str = '',
+    read_state: str = '',
+    sort_by: str = Query(default='import_time', pattern='^(import_time|title|source|publish_time)$'),
+    db: Session = Depends(get_db),
+):
+    stmt = select(Article, VideoItem, Source).join(VideoItem, Article.video_item_id == VideoItem.id).join(Source, VideoItem.source_id == Source.id)
     rows = db.execute(stmt).all()
     out = []
-    for art, item in rows:
-        if q and q.lower() not in item.title.lower():
+    for art, item, src in rows:
+        if q and q.lower() not in item.title.lower() and q.lower() not in (item.description or '').lower():
+            continue
+        if source and source.lower() not in src.title.lower():
+            continue
+        if read_state == 'read' and not art.is_read:
+            continue
+        if read_state == 'unread' and art.is_read:
             continue
         ver = db.execute(select(ArticleVersion).where(ArticleVersion.article_id == art.id, ArticleVersion.version == art.latest_version)).scalar_one_or_none()
-        out.append({"article_id": art.id, "title": item.title, "version": art.latest_version, "body_preview": (ver.body[:160] if ver else ''), "video_item_id": item.id})
+        out.append({
+            "article_id": art.id,
+            "title": item.title,
+            "source_title": src.title,
+            "thumbnail_url": item.thumbnail_url,
+            "is_read": art.is_read,
+            "version": art.latest_version,
+            "body_preview": (ver.body[:160] if ver else ''),
+            "video_item_id": item.id,
+            "published_at": item.published_at.isoformat() if item.published_at else None,
+        })
+
+    if sort_by == 'title':
+        out.sort(key=lambda x: x['title'].lower())
+    elif sort_by == 'source':
+        out.sort(key=lambda x: x['source_title'].lower())
+    elif sort_by == 'publish_time':
+        out.sort(key=lambda x: x['published_at'] or '', reverse=True)
     return out
 
 
@@ -109,7 +208,15 @@ def article_detail(article_id: int, db: Session = Depends(get_db)):
         raise HTTPException(404)
     versions = db.execute(select(ArticleVersion).where(ArticleVersion.article_id == article_id).order_by(ArticleVersion.version.desc())).scalars().all()
     item = db.get(VideoItem, article.video_item_id)
-    return {"id": article.id, "title": item.title if item else '', "latest_version": article.latest_version, "versions": [{"version": v.version, "body": v.body, "prompt_snapshot": v.prompt_snapshot} for v in versions]}
+    progress = db.execute(select(ReadingProgress).where(ReadingProgress.article_id == article_id)).scalar_one_or_none()
+    return {
+        "id": article.id,
+        "title": item.title if item else '',
+        "latest_version": article.latest_version,
+        "is_read": article.is_read,
+        "reading_progress": {"position": progress.position, "total": progress.total} if progress else {"position": 0, "total": 0},
+        "versions": [{"version": v.version, "body": v.body, "prompt_snapshot": v.prompt_snapshot, "mode": v.mode} for v in versions],
+    }
 
 
 @router.post('/articles/{article_id}/regenerate')
@@ -120,9 +227,34 @@ def regenerate(article_id: int, db: Session = Depends(get_db)):
     item = db.get(VideoItem, article.video_item_id)
     if not item:
         raise HTTPException(404, "video item not found")
-    from app.services.pipeline import process_video_item
     process_video_item(db, item.id)
     return {"regenerated": True}
+
+
+@router.post('/articles/{article_id}/read-state')
+def mark_read_state(article_id: int, payload: MarkReadPayload, db: Session = Depends(get_db)):
+    article = db.get(Article, article_id)
+    if not article:
+        raise HTTPException(404)
+    article.is_read = payload.is_read
+    db.commit()
+    return {"saved": True}
+
+
+@router.post('/articles/{article_id}/progress')
+def upsert_reading_progress(article_id: int, payload: ReadingProgressPayload, db: Session = Depends(get_db)):
+    article = db.get(Article, article_id)
+    if not article:
+        raise HTTPException(404)
+    progress = db.execute(select(ReadingProgress).where(ReadingProgress.article_id == article_id)).scalar_one_or_none()
+    if not progress:
+        progress = ReadingProgress(article_id=article_id, position=payload.position, total=payload.total)
+        db.add(progress)
+    else:
+        progress.position = payload.position
+        progress.total = payload.total
+    db.commit()
+    return {"saved": True}
 
 
 @router.get('/collections')
@@ -131,8 +263,8 @@ def collections(db: Session = Depends(get_db)):
 
 
 @router.post('/collections')
-def create_collection(body: dict, db: Session = Depends(get_db)):
-    col = Collection(name=body['name'])
+def create_collection(body: CollectionCreate, db: Session = Depends(get_db)):
+    col = Collection(name=body.name)
     db.add(col)
     db.commit()
     db.refresh(col)
@@ -140,38 +272,53 @@ def create_collection(body: dict, db: Session = Depends(get_db)):
 
 
 @router.get('/diagnostics')
-def diagnostics():
+def diagnostics(db: Session = Depends(get_db)):
     import shutil
-    from app.db.session import SessionLocal
 
-    ffmpeg_detected = False
-    yt_dlp_detected = False
     ffmpeg_command = "ffmpeg"
     yt_dlp_command = "yt-dlp"
 
-    db = SessionLocal()
-    try:
-        rows = db.execute(select(AppSetting).where(AppSetting.key.in_(["ffmpeg_path", "yt_dlp_path"]))).scalars().all()
-        settings_map = {row.key: row.value.strip() for row in rows}
-        ffmpeg_command = settings_map.get("ffmpeg_path") or ffmpeg_command
-        yt_dlp_command = settings_map.get("yt_dlp_path") or yt_dlp_command
-    finally:
-        db.close()
+    rows = db.execute(select(AppSetting).where(AppSetting.key.in_(["ffmpeg_path", "yt_dlp_path"]))).scalars().all()
+    settings_map = {row.key: row.value.strip() for row in rows}
+    ffmpeg_command = settings_map.get("ffmpeg_path") or ffmpeg_command
+    yt_dlp_command = settings_map.get("yt_dlp_path") or yt_dlp_command
 
-    ffmpeg_detected = bool(shutil.which(ffmpeg_command) or (ffmpeg_command and shutil.which("ffmpeg")))
-    yt_dlp_detected = bool(shutil.which(yt_dlp_command) or (yt_dlp_command and shutil.which("yt-dlp")))
+    ffmpeg_detected = bool(shutil.which(ffmpeg_command) or shutil.which("ffmpeg"))
+    yt_dlp_path = shutil.which(yt_dlp_command) or shutil.which("yt-dlp")
+    yt_dlp_detected = bool(yt_dlp_path)
 
     return {
         'ffmpeg': ffmpeg_detected,
         'ffmpeg_command': ffmpeg_command,
         'yt_dlp': yt_dlp_detected,
         'yt_dlp_command': yt_dlp_command,
+        'yt_dlp_path': yt_dlp_path or '',
         'faster_whisper': True,
         'db': True,
-        'queue': True,
+        'scheduler': scheduler_status(),
     }
 
 
+@router.get('/scheduler/status')
+def get_scheduler_status():
+    return scheduler_status()
+
+
 @router.get('/logs')
-def logs(db: Session = Depends(get_db)):
-    return db.execute(select(LogEvent).order_by(LogEvent.created_at.desc()).limit(200)).scalars().all()
+def logs(
+    severity: str = '',
+    context: str = '',
+    q: str = '',
+    db: Session = Depends(get_db),
+):
+    rows = db.execute(select(LogEvent).order_by(LogEvent.created_at.desc()).limit(500)).scalars().all()
+    out = []
+    for row in rows:
+        if severity and row.severity.lower() != severity.lower():
+            continue
+        if context and context.lower() not in row.context.lower():
+            continue
+        if q and q.lower() not in row.message.lower():
+            continue
+        out.append(row)
+    return out

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -7,7 +9,8 @@ from app.db.session import engine
 from app.workers.scheduler import start_scheduler
 
 app = FastAPI(title='ReimagineDoomscrolling API')
-app.add_middleware(CORSMiddleware, allow_origins=['*'], allow_methods=['*'], allow_headers=['*'])
+allowed_origins = [origin.strip() for origin in os.getenv('CORS_ORIGINS', 'http://localhost:5173,http://127.0.0.1:5173').split(',') if origin.strip()]
+app.add_middleware(CORSMiddleware, allow_origins=allowed_origins, allow_methods=['*'], allow_headers=['*'])
 
 
 @app.on_event('startup')

--- a/backend/app/models/entities.py
+++ b/backend/app/models/entities.py
@@ -145,6 +145,25 @@ class Job(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
 
+class JobItem(Base):
+    __tablename__ = "job_items"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    job_id: Mapped[int] = mapped_column(ForeignKey("jobs.id"))
+    video_item_id: Mapped[int | None] = mapped_column(ForeignKey("video_items.id"), nullable=True)
+    status: Mapped[str] = mapped_column(String(50), default="queued")
+    error: Mapped[str] = mapped_column(Text, default="")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class ReadingProgress(Base):
+    __tablename__ = "reading_progress"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    article_id: Mapped[int] = mapped_column(ForeignKey("articles.id"), unique=True)
+    position: Mapped[int] = mapped_column(Integer, default=0)
+    total: Mapped[int] = mapped_column(Integer, default=0)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
 class LogEvent(Base):
     __tablename__ = "log_events"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)

--- a/backend/app/schemas/common.py
+++ b/backend/app/schemas/common.py
@@ -1,5 +1,29 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Message(BaseModel):
     message: str
+
+
+class SettingsPatch(BaseModel):
+    ffmpeg_path: str | None = None
+    yt_dlp_path: str | None = None
+    openai_api_key: str | None = None
+    openai_base_url: str | None = None
+    lmstudio_base_url: str | None = None
+    scheduler_enabled: bool | None = None
+    scheduler_default_cadence_minutes: int | None = Field(default=None, ge=5, le=24 * 60)
+    scheduler_concurrency_cap: int | None = Field(default=None, ge=1, le=16)
+
+
+class CollectionCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+
+
+class MarkReadPayload(BaseModel):
+    is_read: bool
+
+
+class ReadingProgressPayload(BaseModel):
+    position: int = Field(ge=0)
+    total: int = Field(ge=0)

--- a/backend/app/schemas/source.py
+++ b/backend/app/schemas/source.py
@@ -1,14 +1,29 @@
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class SourceCreate(BaseModel):
     url: str
     title: str = ""
-    cadence_minutes: int = 60
+    cadence_minutes: int = Field(default=60, ge=5, le=24 * 60)
     discovery_mode: str = "latest_n"
-    max_videos: int = 10
+    max_videos: int = Field(default=10, ge=1, le=200)
+
+
+class SourcePatch(BaseModel):
+    title: str | None = None
+    state: str | None = None
+    cadence_minutes: int | None = Field(default=None, ge=5, le=24 * 60)
+    discovery_mode: str | None = None
+    max_videos: int | None = Field(default=None, ge=1, le=200)
+    rolling_window_hours: int | None = Field(default=None, ge=1, le=24 * 14)
+    skip_shorts: bool | None = None
+    min_duration_seconds: int | None = Field(default=None, ge=0, le=60 * 60 * 8)
+    skip_livestreams: bool | None = None
+    transcript_strategy: str | None = None
+    fallback_enabled: bool | None = None
+    prompt_override: str | None = None
 
 
 class SourceOut(SourceCreate):

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -1,39 +1,93 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from sqlalchemy import select
 
-from app.models.entities import AppSetting, Article, ArticleVersion, ItemStatus, Job, Source, Transcript, VideoItem
+from app.models.entities import (
+    AppSetting,
+    Article,
+    ArticleVersion,
+    ItemStatus,
+    Job,
+    JobItem,
+    ReadingProgress,
+    RefreshRun,
+    Source,
+    Transcript,
+    VideoItem,
+)
 from app.services.generation import ProviderConfig, generate_article, render_prompt
 from app.services.transcript import fetch_transcript, should_fallback_to_transcription, transcribe_audio_locally
 from app.services.youtube import discover_videos, evaluate_video_policy
 
 
+def _get_setting(db, key: str, default: str = "") -> str:
+    row = db.execute(select(AppSetting).where(AppSetting.key == key)).scalar_one_or_none()
+    return row.value if row and row.value is not None else default
+
+
 def refresh_source(db, source_id: int):
     source = db.get(Source, source_id)
+    run = RefreshRun(source_id=source_id, status="running", summary="")
+    db.add(run)
+    db.flush()
+
+    fetched_count = 0
+    filtered_count = 0
+    enqueued_count = 0
+    duplicate_count = 0
+    failed_count = 0
+
     try:
         videos = discover_videos(source)
-    except NotImplementedError as exc:
+        fetched_count = len(videos)
+    except Exception as exc:
         db.add(Job(type="refresh_source", status="failed", source_id=source_id, error=str(exc)))
         source.failure_count += 1
         source.last_scan_at = datetime.utcnow()
+        source.next_run_at = datetime.utcnow() + timedelta(minutes=min(240, max(10, source.cadence_minutes * (2 ** source.failure_count))))
+        run.status = "failed"
+        run.finished_at = datetime.utcnow()
+        run.summary = f"error={exc}"
         db.commit()
         return
 
     for raw in videos:
         allowed, reason = evaluate_video_policy(raw, source)
         if not allowed:
-            item = VideoItem(source_id=source_id, video_id=raw["video_id"], url=raw["url"], title=raw["title"], status=ItemStatus.skipped_by_policy, status_message=reason)
+            filtered_count += 1
+            item = VideoItem(
+                source_id=source_id,
+                video_id=raw["video_id"],
+                url=raw["url"],
+                title=raw["title"],
+                status=ItemStatus.skipped_by_policy,
+                status_message=reason,
+            )
             db.merge(item)
             continue
         exists = db.execute(select(VideoItem).where(VideoItem.source_id == source_id, VideoItem.video_id == raw["video_id"])).scalar_one_or_none()
         if exists:
+            duplicate_count += 1
             continue
         item = VideoItem(source_id=source_id, video_id=raw["video_id"], url=raw["url"], title=raw["title"], status=ItemStatus.queued)
         db.add(item)
         db.flush()
-        process_video_item(db, item.id)
+        enqueued_count += 1
+        try:
+            process_video_item(db, item.id)
+        except Exception:
+            failed_count += 1
+
     source.last_scan_at = datetime.utcnow()
     source.last_success_at = datetime.utcnow()
+    source.failure_count = 0
+    source.next_run_at = datetime.utcnow() + timedelta(minutes=source.cadence_minutes)
+    run.status = "done"
+    run.finished_at = datetime.utcnow()
+    run.summary = (
+        f"fetched={fetched_count};filtered={filtered_count};"
+        f"enqueued={enqueued_count};duplicates={duplicate_count};failed={failed_count}"
+    )
     db.commit()
 
 
@@ -42,45 +96,68 @@ def process_video_item(db, item_id: int):
 
     try:
         item.status = ItemStatus.transcript_searching
-        text, source_kind = fetch_transcript(item.url, ["en"])
+        language_pref = _get_setting(db, "transcript_languages", "en")
+        languages = [lang.strip() for lang in language_pref.split(",") if lang.strip()] or ["en"]
+        text, source_kind = fetch_transcript(item.url, languages)
 
-        if not text and should_fallback_to_transcription("transcript_first", False, True):
+        source = db.get(Source, item.source_id)
+        strategy = source.transcript_strategy if source else "transcript_first"
+        fallback_enabled = source.fallback_enabled if source else True
+
+        if not text and should_fallback_to_transcription(strategy, False, fallback_enabled):
             item.status = ItemStatus.transcription_started
-            yt_dlp_setting = db.execute(select(AppSetting).where(AppSetting.key == "yt_dlp_path")).scalar_one_or_none()
-            yt_dlp_command = yt_dlp_setting.value.strip() if yt_dlp_setting and yt_dlp_setting.value else "yt-dlp"
+            yt_dlp_command = _get_setting(db, "yt_dlp_path", "yt-dlp").strip() or "yt-dlp"
             text = transcribe_audio_locally(item.url, yt_dlp_command=yt_dlp_command)
             source_kind = "local_transcription"
             item.status = ItemStatus.transcription_completed
-        else:
+        elif text:
             item.status = ItemStatus.transcript_found
+        else:
+            item.status = ItemStatus.transcript_unavailable
 
         transcript = db.execute(select(Transcript).where(Transcript.video_item_id == item.id)).scalar_one_or_none()
         if transcript:
             transcript.text = text
             transcript.source = source_kind
+            transcript.language = languages[0]
         else:
-            db.add(Transcript(video_item_id=item.id, text=text, source=source_kind))
+            db.add(Transcript(video_item_id=item.id, text=text, source=source_kind, language=languages[0]))
 
         item.status = ItemStatus.generation_started
-        prompt = render_prompt("Convert to {{mode}} article\n{{transcript}}", text, "detailed")
-        body = generate_article(text, prompt, ProviderConfig(provider="openai", model="gpt-4.1-mini"))
+        provider_name = _get_setting(db, "generation_provider", "openai")
+        model_name = _get_setting(db, "generation_model", "gpt-4.1-mini")
+        mode_name = _get_setting(db, "generation_mode", "detailed")
+        global_template = _get_setting(db, "global_prompt_template", "Convert to {{mode}} article\n{{transcript}}")
+        prompt_template = source.prompt_override if source and source.prompt_override else global_template
+        prompt = render_prompt(prompt_template, text, mode_name)
+        body = generate_article(text, prompt, ProviderConfig(provider=provider_name, model=model_name))
 
         article = db.execute(select(Article).where(Article.video_item_id == item.id)).scalar_one_or_none()
         if not article:
-            article = Article(video_item_id=item.id, title=item.title)
+            article = Article(video_item_id=item.id, title=item.title, latest_version=1)
             db.add(article)
             db.flush()
+            db.add(ReadingProgress(article_id=article.id, position=0, total=0))
             version_num = 1
         else:
             version_num = article.latest_version + 1
             article.latest_version = version_num
 
-        db.add(ArticleVersion(article_id=article.id, version=version_num, mode="detailed", prompt_snapshot=prompt, body=body))
+        db.add(ArticleVersion(article_id=article.id, version=version_num, mode=mode_name, prompt_snapshot=prompt, body=body))
         item.status = ItemStatus.published
-        db.add(Job(type="process_item", status="done", video_item_id=item.id, source_id=item.source_id))
+
+        job = Job(type="process_item", status="done", video_item_id=item.id, source_id=item.source_id)
+        db.add(job)
+        db.flush()
+        db.add(JobItem(job_id=job.id, video_item_id=item.id, status="done"))
     except Exception as exc:
         item.status = ItemStatus.failed
         item.status_message = str(exc)
-        db.add(Job(type="process_item", status="failed", video_item_id=item.id, source_id=item.source_id, error=str(exc)))
+        job = Job(type="process_item", status="failed", video_item_id=item.id, source_id=item.source_id, error=str(exc))
+        db.add(job)
+        db.flush()
+        db.add(JobItem(job_id=job.id, video_item_id=item.id, status="failed", error=str(exc)))
+        db.commit()
+        raise
 
     db.commit()

--- a/backend/app/workers/scheduler.py
+++ b/backend/app/workers/scheduler.py
@@ -4,22 +4,65 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from sqlalchemy import select
 
 from app.db.session import SessionLocal
-from app.models.entities import Source, SourceState
+from app.models.entities import AppSetting, Source, SourceState
 from app.services.pipeline import refresh_source
 
 scheduler = BackgroundScheduler()
 
 
+def _bool_setting(db, key: str, default: bool) -> bool:
+    row = db.execute(select(AppSetting).where(AppSetting.key == key)).scalar_one_or_none()
+    if not row:
+        return default
+    return str(row.value).lower() in {"1", "true", "yes", "on"}
+
+
+def _int_setting(db, key: str, default: int) -> int:
+    row = db.execute(select(AppSetting).where(AppSetting.key == key)).scalar_one_or_none()
+    if not row or not str(row.value).strip():
+        return default
+    try:
+        return int(row.value)
+    except ValueError:
+        return default
+
+
 def tick_sources():
     db = SessionLocal()
     try:
+        if not _bool_setting(db, "scheduler_enabled", True):
+            return
+
+        cap = max(1, _int_setting(db, "scheduler_concurrency_cap", 2))
         sources = db.execute(select(Source).where(Source.state == SourceState.enabled)).scalars().all()
         now = datetime.utcnow()
+
+        processed = 0
         for src in sources:
+            if processed >= cap:
+                break
             if not src.next_run_at or src.next_run_at <= now:
                 refresh_source(db, src.id)
                 src.next_run_at = now + timedelta(minutes=src.cadence_minutes)
+                processed += 1
         db.commit()
+    finally:
+        db.close()
+
+
+def scheduler_status() -> dict:
+    db = SessionLocal()
+    try:
+        enabled = _bool_setting(db, "scheduler_enabled", True)
+        cap = _int_setting(db, "scheduler_concurrency_cap", 2)
+        default_cadence = _int_setting(db, "scheduler_default_cadence_minutes", 60)
+        return {
+            "running": scheduler.running,
+            "enabled": enabled,
+            "concurrency_cap": cap,
+            "default_cadence_minutes": default_cadence,
+            "job_count": len(scheduler.get_jobs()),
+        }
     finally:
         db.close()
 


### PR DESCRIPTION
### Motivation
- Close several roadmap gaps by wiring settings into runtime behavior, improving scheduler control/visibility, and persisting reader progress and job-item records.\
- Harden the refresh/generation pipeline to record run summaries, apply per-source transcript/fallback policy, and consume generation settings for deterministic article versions.\
- Replace permissive dict payloads with typed Pydantic schemas to improve API validation and reduce accidental misconfiguration.\
- Improve operational diagnostics and reduce attack surface by restricting default CORS and redacting secret values from settings API responses.\

### Description
- Added typed request/response schemas and payload models in `backend/app/schemas/common.py` and `backend/app/schemas/source.py` and switched endpoints to use `SettingsPatch`, `SourcePatch`, `CollectionCreate`, `MarkReadPayload`, and `ReadingProgressPayload`.\
- Extended API surface in `backend/app/api/routes.py` with scheduler status (`/scheduler/status`), job detail (`/jobs/{id}`), item/transcript detail and retry endpoints (`/items/{id}`, `/transcripts/{id}`, `/transcripts/{id}/retry`), enhanced library filtering/sorting, and read-state/progress endpoints (`/articles/{id}/read-state`, `/articles/{id}/progress`), and added settings redaction and log filtering.\
- Extended the data model in `backend/app/models/entities.py` with `JobItem` and `ReadingProgress` tables and kept `RefreshRun` for refresh auditing.\
- Hardened pipeline logic in `backend/app/services/pipeline.py` to persist `RefreshRun` summaries, compute backoff-aware `next_run_at` on errors, honor per-source `transcript_strategy` and `fallback_enabled`, consume generation settings (`generation_provider`, `generation_model`, `generation_mode`, `global_prompt_template`, `transcript_languages`), initialize `ReadingProgress` on article creation, and record `Job`/`JobItem` rows.\
- Improved scheduler behavior in `backend/app/workers/scheduler.py` to read `scheduler_enabled` and `scheduler_concurrency_cap` from settings, enforce a concurrency cap, and expose `scheduler_status()` for diagnostics/UI use.\
- Replaced wildcard CORS in `backend/app/main.py` with configurable `CORS_ORIGINS` and limited defaults for local development.\

### Testing
- Ran the backend unit and integration suite with `pytest backend/tests -q`, which completed successfully with `5 passed` and diagnostic warnings only.\
- Verified the refreshed endpoints via the existing integration test in `backend/tests/test_integration.py` that drives settings, source creation, refresh, library listing, and jobs listing.\
- No frontend automated tests were changed in this pass and the test run focused on backend coverage only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9bc81355c8331aba75e63af0b2fba)