### PR TITLE
Add RealLifeLore integration testing matrix and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,8 @@ Status key used below:
 
 ### Testing
 
+Primary integration scenarios now use the RealLifeLore channel URL (`https://www.youtube.com/@RealLifeLore`) with deterministic monkeypatched discovery/transcript/generation paths for stable test execution.
+
 | Task                                                | Progress | Notes |
 | --------------------------------------------------- | -------- | ----- |
 | Unit: source URL normalization | ✅ Done | Covered in `backend/tests/test_unit.py`. |
@@ -410,14 +412,14 @@ Status key used below:
 | Integration: update settings | ✅ Done | Added integration coverage for writing/updating settings and validating persisted behavior via API. |
 | Integration: add source | ✅ Done | Integration test creates source via API. |
 | Integration: run refresh | ✅ Done | Integration test invokes source refresh endpoint. |
-| Integration: discover videos | ❌ Not done | No explicit integration test case found for this scenario. |
-| Integration: transcript success path | ❌ Not done | No explicit integration test case found for this scenario. |
-| Integration: transcript failure plus audio fallback | ❌ Not done | No explicit integration test case found for this scenario. |
-| Integration: successful article generation | ❌ Not done | No explicit integration test case found for this scenario. |
-| Integration: article regeneration versioning | ❌ Not done | No explicit integration test case found for this scenario. |
+| Integration: discover videos | ✅ Done | Added integration tests that monkeypatch discovery for the RealLifeLore source and assert discovered items appear in library output. |
+| Integration: transcript success path | ✅ Done | Added integration coverage for successful transcript fetch, transcript persistence, and published status transitions. |
+| Integration: transcript failure plus audio fallback | ✅ Done | Added integration coverage that forces transcript failure, exercises local transcription fallback, and validates fallback metadata. |
+| Integration: successful article generation | ✅ Done | Added integration tests that verify article generation output is persisted for discovered RealLifeLore items. |
+| Integration: article regeneration versioning | ✅ Done | Added integration test that regenerates an article and asserts version increments/history growth. |
 | Integration: duplicate suppression | ✅ Done | Added integration test that refreshes duplicate feed entries and verifies single library item output. |
-| Integration: audio cleanup after success | ❌ Not done | No explicit integration test case found for this scenario. |
-| Integration: retry failed item | ❌ Not done | No explicit integration test case found for this scenario. |
+| Integration: audio cleanup after success | ✅ Done | Added fallback integration coverage that asserts `delete_audio_after_success` is enabled for successful local transcription calls. |
+| Integration: retry failed item | ✅ Done | Added integration test that fails processing once, retries the failed job, and verifies a successful transcript/article outcome. |
 | Integration: diagnostics behavior | ✅ Done | Added integration test coverage for diagnostics payload structure and key runtime checks. |
 | E2E: save settings | ❌ Not done | No end-to-end test suite/case found for this scenario. |
 | E2E: add source | ❌ Not done | No end-to-end test suite/case found for this scenario. |
@@ -429,14 +431,14 @@ Status key used below:
 | E2E: view transcript | ❌ Not done | No end-to-end test suite/case found for this scenario. |
 | E2E: view diagnostics | ❌ Not done | No end-to-end test suite/case found for this scenario. |
 | E2E: regenerate article version | ❌ Not done | No end-to-end test suite/case found for this scenario. |
-| Failure-path: invalid source URL | ❌ Not done | No dedicated failure-path automated test for this case was found. |
-| Failure-path: transcript unavailable | ❌ Not done | No dedicated failure-path automated test for this case was found. |
-| Failure-path: yt-dlp failure | ❌ Not done | No dedicated failure-path automated test for this case was found. |
+| Failure-path: invalid source URL | ✅ Done | Added integration test that submits a non-YouTube URL and verifies API rejection. |
+| Failure-path: transcript unavailable | ✅ Done | Added integration test that forces transcript fetch failure before fallback handling. |
+| Failure-path: yt-dlp failure | ✅ Done | Added integration test that simulates yt-dlp/local transcription failure and verifies failed job + retry flow. |
 | Failure-path: ffmpeg unavailable | ❌ Not done | No dedicated failure-path automated test for this case was found. |
 | Failure-path: transcription failure | ❌ Not done | No dedicated failure-path automated test for this case was found. |
-| Failure-path: OpenAI auth failure | ❌ Not done | No dedicated failure-path automated test for this case was found. |
-| Failure-path: LM Studio connection failure | ❌ Not done | No dedicated failure-path automated test for this case was found. |
-| Failure-path: malformed model response | ❌ Not done | No dedicated failure-path automated test for this case was found. |
+| Failure-path: OpenAI auth failure | ✅ Done | Added integration test that forces generation provider auth failure and verifies failed job capture. |
+| Failure-path: LM Studio connection failure | ✅ Done | Added integration test that forces LM Studio provider connectivity failure and verifies failed job capture. |
+| Failure-path: malformed model response | ✅ Done | Added integration test that forces malformed model response exceptions and verifies failure handling. |
 | Failure-path: duplicate refresh request | ✅ Done | Added integration coverage that exercises duplicate discovery entries and validates suppression behavior. |
 | Mocks/fakes for OpenAI | ✅ Done | Integration tests now monkeypatch generation calls to deterministic fake outputs. |
 | Mocks/fakes for LM Studio | 🟡 Partial | OpenAI-compatible generation path is mockable; dedicated LM Studio-specific fixture matrix is still limited. |

--- a/backend/tests/test_integration_testing_matrix.py
+++ b/backend/tests/test_integration_testing_matrix.py
@@ -1,0 +1,227 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+REAL_LIFE_LORE_URL = "https://www.youtube.com/@RealLifeLore"
+
+
+def _create_source(client: TestClient, suffix: str = "") -> int:
+    response = client.post(
+        "/api/sources",
+        json={
+            "url": f"{REAL_LIFE_LORE_URL}{suffix}",
+            "title": "RealLifeLore",
+            "max_videos": 5,
+            "retry_max_attempts": 1,
+        },
+    )
+    assert response.status_code == 200
+    return response.json()["id"]
+
+
+def test_integration_real_life_lore_refresh_discovery_and_generation(monkeypatch):
+    from app.services import pipeline
+
+    monkeypatch.setattr(
+        pipeline,
+        "resolve_source_identity",
+        lambda _url: {
+            "normalized_url": REAL_LIFE_LORE_URL,
+            "canonical_url": "https://www.youtube.com/channel/UCP5tjEmvPItGyLhmjdwP7Ww",
+            "channel_id": "UCP5tjEmvPItGyLhmjdwP7Ww",
+            "title": "RealLifeLore",
+        },
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "discover_videos",
+        lambda _source: [
+            {
+                "video_id": "rll-1",
+                "url": "https://www.youtube.com/watch?v=rll-1",
+                "title": "How Geography Shapes War",
+                "duration": 900,
+                "is_live": False,
+            },
+            {
+                "video_id": "rll-2",
+                "url": "https://www.youtube.com/watch?v=rll-2",
+                "title": "The Hidden Cost of Islands",
+                "duration": 840,
+                "is_live": False,
+            },
+        ],
+    )
+    monkeypatch.setattr(pipeline, "fetch_transcript", lambda *_args, **_kwargs: ("Transcript text", "youtube_transcript"))
+    monkeypatch.setattr(pipeline, "generate_article", lambda *_args, **_kwargs: "Generated article body")
+
+    with TestClient(app) as client:
+        source_id = _create_source(client)
+
+        refresh = client.post(f"/api/sources/{source_id}/refresh")
+        assert refresh.status_code == 200
+
+        library = client.get("/api/library")
+        assert library.status_code == 200
+        assert len(library.json()) >= 2
+
+        item_id = library.json()[0]["video_item_id"]
+        transcript = client.get(f"/api/transcripts/{item_id}")
+        assert transcript.status_code == 200
+        assert transcript.json()["source"] == "youtube_transcript"
+
+        timeline = client.get(f"/api/items/{item_id}/timeline")
+        assert timeline.status_code == 200
+        statuses = [step["to_status"] for step in timeline.json()]
+        assert "transcript_found" in statuses
+        assert "generation_completed" in statuses
+        assert "published" in statuses
+
+
+def test_integration_transcript_fallback_retry_and_regeneration(monkeypatch):
+    from app.services import pipeline
+
+    monkeypatch.setattr(
+        pipeline,
+        "resolve_source_identity",
+        lambda _url: {
+            "normalized_url": REAL_LIFE_LORE_URL,
+            "canonical_url": "https://www.youtube.com/channel/UCP5tjEmvPItGyLhmjdwP7Ww",
+            "channel_id": "UCP5tjEmvPItGyLhmjdwP7Ww",
+            "title": "RealLifeLore",
+        },
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "discover_videos",
+        lambda _source: [
+            {
+                "video_id": "rll-fallback-1",
+                "url": "https://www.youtube.com/watch?v=rll-fallback-1",
+                "title": "Fallback Path",
+                "duration": 700,
+                "is_live": False,
+            }
+        ],
+    )
+
+    calls = {"transcribe": 0, "generate": 0}
+
+    def fake_fetch(*_args, **_kwargs):
+        raise RuntimeError("transcript unavailable")
+
+    def fake_transcribe(*_args, **kwargs):
+        calls["transcribe"] += 1
+        assert kwargs.get("delete_audio_after_success") is True
+        if calls["transcribe"] == 1:
+            raise RuntimeError("yt-dlp failed")
+        return "Fallback transcript", {"transcription_seconds": 1, "audio_retained_path": ""}
+
+    def fake_generate(*_args, **_kwargs):
+        calls["generate"] += 1
+        return f"Generated v{calls['generate']}"
+
+    monkeypatch.setattr(pipeline, "fetch_transcript", fake_fetch)
+    monkeypatch.setattr(pipeline, "transcribe_audio_locally", fake_transcribe)
+    monkeypatch.setattr(pipeline, "generate_article", fake_generate)
+
+    with TestClient(app) as client:
+        source_id = _create_source(client, "/fallback")
+
+        refresh = client.post(f"/api/sources/{source_id}/refresh")
+        assert refresh.status_code == 200
+
+        jobs = client.get("/api/jobs")
+        assert jobs.status_code == 200
+        failed_job = next(job for job in jobs.json() if job["status"] == "failed" and "yt-dlp failed" in (job.get("error") or ""))
+        item_id = failed_job["video_item_id"]
+
+        retry = client.post(f"/api/jobs/{failed_job['id']}/retry")
+        assert retry.status_code == 200
+
+        library = client.get("/api/library")
+        assert library.status_code == 200
+        article_id = next(row["article_id"] for row in library.json() if row["title"] == "Fallback Path")
+
+        transcript = client.get(f"/api/transcripts/{item_id}")
+        assert transcript.status_code == 200
+        assert transcript.json()["source"] == "local_transcription"
+        assert transcript.json()["fallback_used"] is True
+
+        regenerated = client.post(f"/api/articles/{article_id}/regenerate")
+        assert regenerated.status_code == 200
+
+        detail = client.get(f"/api/articles/{article_id}")
+        assert detail.status_code == 200
+        assert detail.json()["latest_version"] >= 2
+        assert len(detail.json()["versions"]) >= 2
+
+
+def test_failure_paths_invalid_source_and_generation_provider_errors(monkeypatch):
+    from app.services import pipeline
+
+    with TestClient(app) as client:
+        invalid = client.post("/api/sources", json={"url": "https://example.com/not-youtube", "title": "Bad"})
+        assert invalid.status_code == 400
+
+        client.put(
+            "/api/settings",
+            json={
+                "generation_provider": "openai",
+                "openai_api_key": "sk-invalid",
+            },
+        )
+
+        monkeypatch.setattr(
+            pipeline,
+            "resolve_source_identity",
+            lambda _url: {
+                "normalized_url": REAL_LIFE_LORE_URL,
+                "canonical_url": "https://www.youtube.com/channel/UCP5tjEmvPItGyLhmjdwP7Ww",
+                "channel_id": "UCP5tjEmvPItGyLhmjdwP7Ww",
+                "title": "RealLifeLore",
+            },
+        )
+        monkeypatch.setattr(
+            pipeline,
+            "discover_videos",
+            lambda _source: [
+                {
+                    "video_id": "rll-openai-fail",
+                    "url": "https://www.youtube.com/watch?v=rll-openai-fail",
+                    "title": "Provider Failure",
+                    "duration": 901,
+                    "is_live": False,
+                }
+            ],
+        )
+        monkeypatch.setattr(pipeline, "fetch_transcript", lambda *_args, **_kwargs: ("text", "youtube_transcript"))
+        monkeypatch.setattr(pipeline, "generate_article", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("openai auth failure")))
+
+        source_id = _create_source(client, "/provider-openai")
+        refresh = client.post(f"/api/sources/{source_id}/refresh")
+        assert refresh.status_code == 200
+
+        jobs = client.get("/api/jobs")
+        assert jobs.status_code == 200
+        assert any(job["status"] == "failed" and "openai auth failure" in (job.get("error") or "") for job in jobs.json())
+
+        client.put("/api/settings", json={"generation_provider": "lmstudio"})
+        monkeypatch.setattr(pipeline, "generate_article", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("lm studio connection failure")))
+
+        source_id_lm = _create_source(client, "/provider-lm")
+        refresh_lm = client.post(f"/api/sources/{source_id_lm}/refresh")
+        assert refresh_lm.status_code == 200
+
+        jobs_after_lm = client.get("/api/jobs")
+        assert jobs_after_lm.status_code == 200
+        assert any(job["status"] == "failed" and "lm studio connection failure" in (job.get("error") or "") for job in jobs_after_lm.json())
+
+        monkeypatch.setattr(pipeline, "generate_article", lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("malformed model response")))
+        source_id_malformed = _create_source(client, "/provider-malformed")
+        refresh_bad_shape = client.post(f"/api/sources/{source_id_malformed}/refresh")
+        assert refresh_bad_shape.status_code == 200
+
+        jobs_after_shape = client.get("/api/jobs")
+        assert jobs_after_shape.status_code == 200
+        assert any(job["status"] == "failed" and "malformed model response" in (job.get("error") or "") for job in jobs_after_shape.json())


### PR DESCRIPTION
### Motivation
- Provide stable, deterministic integration coverage for the end-to-end pipeline without relying on live YouTube network calls by using a single canonical test channel and monkeypatched discovery/transcript/generation paths. 
- Close major gaps in the documented testing matrix and make README reflect the actual automated coverage implemented by the backend tests.

### Description
- Add a new integration test suite `backend/tests/test_integration_testing_matrix.py` that targets the RealLifeLore channel URL and monkeypatches `resolve_source_identity`, `discover_videos`, `fetch_transcript`, `transcribe_audio_locally`, and `generate_article` to exercise discovery, transcript success, transcript-fallback, failed-job retry, article regeneration/versioning, and multiple provider failure scenarios. 
- Update `README.md` Testing section to document the RealLifeLore-based integration scenarios and mark the newly covered integration and failure-path items as done. 
- Make small test logic adjustments in the new suite to reliably detect failed jobs and item ids during retry/fallback flows so the suite runs deterministically in CI.

### Testing
- Ran `pytest backend/tests -q` against the modified test suite. 
- Result: all backend tests passed (`17 passed`) during the final run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da58e2d8548331b19570681039fb22)