### PR TITLE
Fix YouTube source resolution so channel imports discover videos

### DIFF
--- a/backend/app/services/youtube.py
+++ b/backend/app/services/youtube.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from datetime import datetime, timedelta
 from email.utils import parsedate_to_datetime
 from urllib.parse import parse_qs, urlparse
@@ -8,19 +9,21 @@ import httpx
 
 
 YOUTUBE_FEED_BASE = "https://www.youtube.com/feeds/videos.xml"
+CHANNEL_ID_PATTERN = re.compile(r'"externalId":"(UC[0-9A-Za-z_-]{20,})"')
 
 
 def normalize_source_url(url: str) -> str:
     url = url.strip()
     if "youtube.com" not in url and "youtu.be" not in url:
         raise ValueError("Only YouTube URLs are supported")
-    if "@" in url:
-        return url.split("?")[0]
     parsed = urlparse(url)
-    if parsed.path.startswith("/channel/"):
-        return f"https://www.youtube.com{parsed.path}"
-    if parsed.path.startswith("/c/") or parsed.path.startswith("/user/"):
-        return f"https://www.youtube.com{parsed.path}"
+    path = parsed.path.rstrip("/")
+    if path.startswith("/@"):
+        return f"https://www.youtube.com{path}"
+    if path.startswith("/channel/"):
+        return f"https://www.youtube.com{path}"
+    if path.startswith("/c/") or path.startswith("/user/"):
+        return f"https://www.youtube.com{path}"
     return url
 
 
@@ -38,19 +41,28 @@ def evaluate_video_policy(video: dict, source) -> tuple[bool, str]:
     return True, "ok"
 
 
-def _feed_url_from_source_url(source_url: str) -> str:
+def _extract_channel_id_from_page(source_url: str) -> str:
+    with httpx.Client(timeout=20.0, follow_redirects=True) as client:
+        response = client.get(source_url)
+        response.raise_for_status()
+    match = CHANNEL_ID_PATTERN.search(response.text)
+    return match.group(1) if match else ""
+
+
+def _feed_url_from_source_url(source_url: str, channel_id: str = "") -> str:
+    if channel_id:
+        return f"{YOUTUBE_FEED_BASE}?channel_id={channel_id}"
+
     parsed = urlparse(source_url)
     path = parsed.path.rstrip("/")
 
     if path.startswith("/channel/"):
-        channel_id = path.split("/", 2)[2]
-        return f"{YOUTUBE_FEED_BASE}?channel_id={channel_id}"
-    if path.startswith("/@"):
-        handle = path.split("/@", 1)[1]
-        return f"{YOUTUBE_FEED_BASE}?user={handle}"
-    if path.startswith("/user/"):
-        username = path.split("/user/", 1)[1]
-        return f"{YOUTUBE_FEED_BASE}?user={username}"
+        source_channel_id = path.split("/", 2)[2]
+        return f"{YOUTUBE_FEED_BASE}?channel_id={source_channel_id}"
+    if path.startswith("/@") or path.startswith("/c/") or path.startswith("/user/"):
+        resolved_channel_id = _extract_channel_id_from_page(source_url)
+        if resolved_channel_id:
+            return f"{YOUTUBE_FEED_BASE}?channel_id={resolved_channel_id}"
 
     query = parse_qs(parsed.query)
     if "channel_id" in query and query["channel_id"]:
@@ -121,7 +133,7 @@ def resolve_source_identity(source_url: str) -> dict:
 
 def discover_videos(source) -> list[dict]:
     try:
-        feed_url = _feed_url_from_source_url(source.url)
+        feed_url = _feed_url_from_source_url(source.canonical_url or source.url, source.channel_id or "")
     except ValueError:
         return []
 

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -4,7 +4,38 @@ import pytest
 
 from app.services.generation import ProviderConfig, generate_article, render_prompt
 from app.services.transcript import should_fallback_to_transcription
-from app.services.youtube import evaluate_video_policy, normalize_source_url
+from app.services.youtube import evaluate_video_policy, normalize_source_url, resolve_source_identity
+
+
+def test_resolve_source_identity_supports_handle_urls(monkeypatch):
+    channel_id = "UCabcdefghijklmnopqrstuvwxyz123456"
+
+    class FakeResponse:
+        def __init__(self, text):
+            self.text = text
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url):
+            if "feeds/videos.xml" in url:
+                return FakeResponse(f"""<?xml version='1.0' encoding='UTF-8'?><feed xmlns='http://www.w3.org/2005/Atom' xmlns:yt='http://www.youtube.com/xml/schemas/2015'><title>My Channel</title><yt:channelId>{channel_id}</yt:channelId><entry><yt:videoId>abc123</yt:videoId><title>Video</title><published>Wed, 01 Jan 2025 00:00:00 GMT</published></entry></feed>""")
+            return FakeResponse(f'<html><script>"externalId":"{channel_id}"</script></html>')
+
+    monkeypatch.setattr("app.services.youtube.httpx.Client", FakeClient)
+    resolved = resolve_source_identity("https://www.youtube.com/@myhandle")
+    assert resolved["channel_id"] == channel_id
+    assert resolved["canonical_url"] == f"https://www.youtube.com/channel/{channel_id}"
 
 
 def test_normalize_url():


### PR DESCRIPTION
### Motivation

- Many common YouTube source URL formats (e.g. `@handle`, `/c/...`, `/user/...`) were not resolving to a feedable channel identity, causing newly-added sources to refresh with no discovered videos.

### Description

- Add HTML `externalId` extraction (`CHANNEL_ID_PATTERN`) and `_extract_channel_id_from_page` to resolve a channel ID from channel pages when needed.
- Update feed URL construction in `_feed_url_from_source_url` to prefer a resolved `channel_id` and to attempt page-derived resolution for handle/`/c/`/`/user/` paths.
- Make `discover_videos` prefer persisted canonical identity (`source.canonical_url` / `source.channel_id`) when building the feed URL so refreshes after import reliably fetch items.
- Add a unit test that mocks `httpx.Client` responses and asserts that `resolve_source_identity` resolves handle URLs to a canonical `channel_id`/URL.

### Testing

- Ran `pytest backend/tests -q` and all tests passed (`18 passed`, 3 warnings).
- Ran `pytest backend/tests/test_unit.py -q` and unit tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da5d1a49e883319fc096236b5ca18f)