### PR TITLE
feat(frontend): modernize UI with product-grade visual system

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -67,7 +67,10 @@ type ItemTransition = {
 function Page({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <section className='page'>
-      <h1>{title}</h1>
+      <div className='page-header'>
+        <h1>{title}</h1>
+        <p className='muted'>Control your reading pipeline with a cleaner, calmer workflow.</p>
+      </div>
       {children}
     </section>
   );
@@ -85,6 +88,13 @@ function Home() {
 
   return (
     <Page title='Dashboard'>
+      <article className='card hero'>
+        <div>
+          <p className='eyebrow'>Overview</p>
+          <h2>Turn noisy video feeds into a focused reading queue.</h2>
+          <p className='muted'>Track ingestion, quality, and progress without jumping between screens.</p>
+        </div>
+      </article>
       <div className='grid'>
         <article className='card stat'><p className='label'>Sources</p><p className='value'>{sources.data?.length ?? 0}</p></article>
         <article className='card stat'><p className='label'>Active sources</p><p className='value'>{activeSources}</p></article>
@@ -352,7 +362,11 @@ function Layout() {
   const links = [['/', 'Home'], ['/sources', 'Sources'], ['/jobs', 'Jobs'], ['/library', 'Library'], ['/collections', 'Collections'], ['/settings', 'Settings'], ['/diagnostics', 'Diagnostics'], ['/logs', 'Logs']] as const;
   return (
     <div className='layout'>
-      <aside><h2>ReimagineDoomscrolling</h2><nav>{links.map(([href, label]) => <NavLink key={href} to={href} className={({ isActive }) => (isActive ? 'active' : '')} end={href === '/'}>{label}</NavLink>)}</nav></aside>
+      <aside>
+        <h2>ReimagineDoomscrolling</h2>
+        <p className='muted product-subtitle'>Reader OS</p>
+        <nav>{links.map(([href, label]) => <NavLink key={href} to={href} className={({ isActive }) => (isActive ? 'active' : '')} end={href === '/'}>{label}</NavLink>)}</nav>
+      </aside>
       <main>
         <Routes>
           <Route path='/' element={<Home />} />

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,89 +1,162 @@
 :root {
-  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
-  color: #e6e9ef;
-  background: #0f1324;
+  font-family: Inter, "SF Pro Text", system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  color: #dbe7ff;
+  background: #070b17;
+  --surface: rgba(12, 20, 44, 0.76);
+  --surface-strong: rgba(14, 24, 52, 0.94);
+  --border: rgba(167, 191, 255, 0.22);
+  --muted: #a8b7dc;
+  --accent: #7aa2ff;
 }
 
 * { box-sizing: border-box; }
-body { margin: 0; min-height: 100vh; background: radial-gradient(circle at top, #1f2854 0%, #0f1324 50%, #0a0d19 100%); }
-a { color: #8ecbff; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: inherit;
+  background:
+    radial-gradient(1200px 700px at 10% -10%, #2f4fb8 0%, transparent 55%),
+    radial-gradient(900px 500px at 100% 0%, #6b42be 0%, transparent 50%),
+    linear-gradient(180deg, #080c19 0%, #070b17 60%, #05070f 100%);
+}
+
+a { color: #9ec2ff; }
 
 .layout {
   display: grid;
-  grid-template-columns: 260px 1fr;
+  grid-template-columns: 280px minmax(0, 1fr);
   min-height: 100vh;
 }
 
 aside {
-  padding: 1.5rem;
-  background: rgba(10, 14, 31, 0.85);
-  border-right: 1px solid rgba(255, 255, 255, 0.08);
-  backdrop-filter: blur(6px);
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  padding: 1.75rem 1.15rem;
+  background: linear-gradient(180deg, rgba(9, 13, 27, .98), rgba(8, 11, 23, .9));
+  border-right: 1px solid rgba(136, 164, 237, 0.2);
+  backdrop-filter: blur(14px);
 }
-
-aside h2 { font-size: 1.1rem; margin-top: 0; }
-aside nav { display: flex; flex-direction: column; gap: .4rem; }
+aside h2 { margin: 0; font-size: 1.1rem; letter-spacing: .01em; }
+.product-subtitle { margin: .35rem 0 1rem; text-transform: uppercase; font-size: .72rem; letter-spacing: .13em; }
+aside nav { display: grid; gap: .4rem; }
 aside nav a {
   text-decoration: none;
-  padding: .6rem .8rem;
-  border-radius: 8px;
-  color: #c8d3f5;
+  padding: .74rem .86rem;
+  border-radius: 12px;
+  color: #d0dcff;
+  border: 1px solid transparent;
+  transition: .2s ease;
 }
-aside nav a.active, aside nav a:hover { background: rgba(144, 202, 249, .2); color: #fff; }
+aside nav a:hover {
+  border-color: rgba(167, 191, 255, 0.24);
+  background: rgba(71, 111, 255, .14);
+}
+aside nav a.active {
+  background: linear-gradient(125deg, rgba(83, 118, 255, 0.4), rgba(140, 91, 221, 0.35));
+  border-color: rgba(182, 203, 255, 0.35);
+  color: #fff;
+  box-shadow: 0 10px 30px rgba(62, 95, 200, .3);
+}
 
-main { padding: 1.5rem; }
-.page h1 { margin-top: 0; }
+main { padding: 2rem; }
+.page { display: grid; gap: 1rem; }
+.page-header h1 { margin: 0; font-size: clamp(1.6rem, 2.5vw, 2rem); }
+.page-header p { margin: .35rem 0 0; }
 
-.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 1rem; }
-.stack { display: grid; gap: .75rem; padding-left: 1rem; }
-.row { display: flex; flex-wrap: wrap; gap: .8rem; align-items: end; }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 1rem; }
+.stack { display: grid; gap: .85rem; padding-left: 1rem; }
+.row { display: flex; flex-wrap: wrap; gap: .8rem; align-items: center; }
 .space-between { justify-content: space-between; }
-.thumb { width: 100%; max-height: 160px; object-fit: cover; border-radius: 10px; margin-bottom: .5rem; }
-.badge { font-size: .75rem; padding: .15rem .35rem; border: 1px solid rgba(255,255,255,.25); border-radius: 999px; }
-.linkish { background: transparent; border: none; color: #8ecbff; padding: 0; }
 
 .card {
-  background: rgba(21, 29, 61, .72);
-  border: 1px solid rgba(255, 255, 255, .1);
-  border-radius: 14px;
-  padding: 1rem;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, .22);
+  background: linear-gradient(160deg, rgba(14, 24, 52, 0.96), rgba(11, 18, 38, 0.86));
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1.05rem;
+  box-shadow: 0 16px 45px rgba(1, 4, 12, .45), inset 0 1px 0 rgba(197, 211, 255, .12);
 }
+.card h2, .card h3 { margin-top: 0; }
+.hero { padding: 1.4rem; background: linear-gradient(125deg, rgba(62, 107, 255, 0.33), rgba(132, 85, 218, 0.3)); }
+.eyebrow { margin: 0 0 .35rem; font-size: .73rem; letter-spacing: .14em; text-transform: uppercase; color: #d6e3ff; }
 
-.stat .label { margin: 0; color: #afbbdf; text-transform: uppercase; font-size: .74rem; }
-.stat .value { margin: .35rem 0 0; font-size: 1.6rem; font-weight: 700; }
-.muted { color: #aeb9d7; }
+.stat { position: relative; overflow: hidden; }
+.stat::after {
+  content: "";
+  position: absolute;
+  width: 120px;
+  height: 120px;
+  right: -40px;
+  bottom: -52px;
+  background: radial-gradient(circle, rgba(132, 185, 255, .25), transparent 70%);
+}
+.stat .label { margin: 0; color: #b8c7ed; text-transform: uppercase; font-size: .72rem; letter-spacing: .07em; }
+.stat .value { margin: .35rem 0 0; font-size: 1.86rem; font-weight: 700; }
+
+.muted { color: var(--muted); }
+.badge {
+  font-size: .7rem;
+  padding: .2rem .48rem;
+  border: 1px solid rgba(201, 215, 255, .28);
+  border-radius: 999px;
+  background: rgba(112, 157, 255, 0.12);
+}
+.linkish { background: transparent; border: none; color: #a9cbff; padding: 0; font-size: 1rem; }
+.thumb { width: 100%; max-height: 185px; object-fit: cover; border-radius: 12px; margin-bottom: .6rem; border: 1px solid rgba(167, 191, 255, 0.24); }
 
 input, select, button {
-  background: #0c122c;
+  background: var(--surface-strong);
   color: #edf2ff;
-  border: 1px solid rgba(255, 255, 255, .18);
-  border-radius: 8px;
-  padding: .55rem .7rem;
+  border: 1px solid rgba(165, 189, 255, 0.27);
+  border-radius: 10px;
+  padding: .58rem .75rem;
+  font: inherit;
+}
+
+input:focus, select:focus, button:focus {
+  outline: 2px solid rgba(136, 177, 255, 0.54);
+  outline-offset: 1px;
 }
 
 button {
-  background: linear-gradient(135deg, #5066ff 0%, #7f56d9 100%);
+  background: linear-gradient(135deg, #4f78ff 0%, #8458d7 100%);
   border: none;
+  font-weight: 620;
   cursor: pointer;
-  font-weight: 600;
+  box-shadow: 0 6px 18px rgba(79, 120, 255, .3);
 }
-button:disabled { opacity: .6; cursor: default; }
+button:hover { transform: translateY(-1px); }
+button:disabled { opacity: .65; cursor: default; transform: none; }
 
 table { width: 100%; border-collapse: collapse; }
-th, td { text-align: left; border-bottom: 1px solid rgba(255, 255, 255, .08); padding: .55rem .3rem; }
-.reader pre { white-space: pre-wrap; line-height: 1.5; font-family: inherit; margin: 0; }
-.reader { margin-top: 1rem; }
+th, td { text-align: left; border-bottom: 1px solid rgba(174, 197, 255, .16); padding: .68rem .35rem; }
+th { color: #bfd0ff; font-weight: 600; }
+
+.reader { margin-top: .4rem; }
+.reader pre { white-space: pre-wrap; line-height: 1.7; font-family: inherit; margin: 0; }
 .reader .tabs { display: flex; gap: .5rem; margin-bottom: .7rem; }
-.reader .tabs button.active { outline: 2px solid #8ecbff; }
-.reader .reader-scroll { max-height: 60vh; overflow: auto; }
-.reader-light { background: #f7f7f3; color: #1d1f24; }
-.reader-sepia { background: #f3e8d1; color: #3f3221; }
-.reader-dark { background: rgba(21, 29, 61, .72); color: #e6e9ef; }
-.reader-font-serif { font-family: Georgia, 'Times New Roman', serif; }
+.reader .tabs button { box-shadow: none; }
+.reader .tabs button.active { background: linear-gradient(125deg, #3e6bff, #8a5adb); }
+.reader .reader-scroll {
+  max-height: 62vh;
+  overflow: auto;
+  padding: .5rem .2rem .2rem;
+  scrollbar-width: thin;
+}
+
+.reader-light { background: #f4f6fa; color: #1d2436; }
+.reader-sepia { background: #f5ead6; color: #3e3020; }
+.reader-dark { background: linear-gradient(160deg, rgba(14, 24, 52, 0.96), rgba(11, 18, 38, 0.86)); color: #e6ecff; }
+.reader-font-serif { font-family: "Iowan Old Style", Georgia, "Times New Roman", serif; }
 .reader-font-sans { font-family: Inter, system-ui, sans-serif; }
 
-@media (max-width: 820px) {
+@media (max-width: 1024px) {
   .layout { grid-template-columns: 1fr; }
-  aside { border-right: none; border-bottom: 1px solid rgba(255, 255, 255, 0.08); }
+  aside {
+    position: static;
+    height: auto;
+    border-right: none;
+    border-bottom: 1px solid rgba(136, 164, 237, 0.2);
+  }
+  main { padding: 1rem; }
 }


### PR DESCRIPTION
### Motivation
- Refresh the frontend so the app looks like a polished product instead of a framework/test prototype. 
- Improve information hierarchy and reduce visual noise so users can manage ingestion, quality, and reading progress in a calmer UI.

### Description
- Added a contextual page header to `Page` with helper copy to improve framing across pages and added a hero block on the Dashboard for clearer top-level messaging (`frontend/src/main.tsx`).
- Enhanced the sidebar with a branded subtitle and improved navigation affordances to present a more intentional app shell (`frontend/src/main.tsx`).
- Replaced and upgraded the global styles with a cohesive visual system (CSS variables, refined gradients, sticky glassy sidebar, elevated cards, improved nav hover/active states, modernized form controls, badges, tables, and reader presentation) in `frontend/src/styles.css`.
- Ensured responsive behavior (adjusted layout and sidebar behavior on smaller screens) and minor spacing/typography refinements across components.

### Testing
- Ran the production build with `cd frontend && npm run build`, which completed successfully (build artifacts generated).
- The build produced non-fatal warnings related to module-level directives in `@tanstack/react-query`, but the output bundle was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da5fa4d13c833195211950ba5c0964)