### PR TITLE
Add manual refresh controls, editable prompt template, and raw transcript (no-AI) generation

### DIFF
--- a/backend/app/services/generation.py
+++ b/backend/app/services/generation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import httpx
+import re
 
 from app.core.config import settings
 
@@ -59,11 +60,27 @@ def _chat_completion(base_url: str, api_key: str, model: str, prompt: str, tempe
     return body["choices"][0]["message"]["content"].strip()
 
 
+def _clean_raw_transcript(transcript: str) -> str:
+    lines = []
+    for raw_line in transcript.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        line = re.sub(r"^\[?\d{1,2}:\d{2}(?::\d{2})?(?:\.\d+)?\]?\s*[-–—]?\s*", "", line)
+        line = re.sub(r"^\d+\s*$", "", line).strip()
+        if line:
+            lines.append(line)
+    return "\n".join(lines)
+
+
 def generate_article(transcript: str, prompt: str, cfg: ProviderConfig) -> str:
     if not transcript.strip():
         return ""
 
     provider = (cfg.provider or "openai").lower()
+    if provider in {"none", "raw", "raw_transcript"}:
+        return _clean_raw_transcript(transcript)
+
     if provider == "openai":
         if not (cfg.openai_api_key or settings.openai_api_key):
             raise ValueError("OPENAI_API_KEY is required when provider is openai")

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -67,7 +67,7 @@ type ItemTransition = {
 type SettingField = {
   key: string;
   label: string;
-  type: 'text' | 'password' | 'url' | 'select' | 'range';
+  type: 'text' | 'password' | 'url' | 'select' | 'range' | 'textarea';
   description?: string;
   options?: Array<{ label: string; value: string }>;
   min?: number;
@@ -105,6 +105,7 @@ function Home() {
           <h2>Turn noisy video feeds into a focused reading queue.</h2>
           <p className='muted'>Track ingestion, quality, and progress without jumping between screens.</p>
         </div>
+        <button onClick={() => { sources.refetch(); jobs.refetch(); library.refetch(); scheduler.refetch(); }}>Refresh dashboard</button>
       </article>
       <div className='grid'>
         <article className='card stat'><p className='label'>Sources</p><p className='value'>{sources.data?.length ?? 0}</p></article>
@@ -235,6 +236,7 @@ function Library() {
         <select value={collection_id} onChange={(e) => set('collection_id', e.target.value)}><option value=''>All collections</option>{(collections.data ?? []).map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}</select>
         <select value={view} onChange={(e) => set('view', e.target.value)}><option value='grid'>Grid</option><option value='list'>List</option></select>
         <label><input type='checkbox' checked={group_by_source} onChange={(e) => set('group_by_source', e.target.checked ? 'true' : '')} /> Group by source</label>
+        <button onClick={() => library.refetch()}>Refresh results</button>
       </article>
       {grouped
         ? (library.data as any[]).map((group) => <section key={group.source_title}><h2>{group.source_title}</h2>{cards(group.items)}</section>)
@@ -295,6 +297,7 @@ function Reader() {
         <div className='row'>
           <label>Version <select value={version?.version ?? ''} onChange={(e) => setSelectedVersion(Number(e.target.value))}>{(detail.data?.versions ?? []).map((v: any) => <option key={v.version} value={v.version}>v{v.version}</option>)}</select></label>
           <button onClick={() => regenerate.mutate()}>Regenerate</button>
+          <button onClick={() => { detail.refetch(); transcript.refetch(); timeline.refetch(); }}>Refresh data</button>
           <button onClick={() => markRead.mutate(!detail.data?.is_read)}>{detail.data?.is_read ? 'Mark unread' : 'Mark read'}</button>
           <button onClick={() => navigator.clipboard.writeText(body)}>Copy</button>
           <span className='muted'>~{estMinutes} min read</span>
@@ -347,7 +350,7 @@ function Settings() {
     timezone: 'UTC', ui_theme_default: 'dark',
     source_default_discovery_mode: 'latest_n', source_default_max_videos: '10', source_default_rolling_window_hours: '72', source_default_skip_shorts: 'true', source_default_min_duration_seconds: '180', source_default_dedup_policy: 'source_video_id',
     transcript_languages: 'en', transcript_first: 'true', transcript_fallback_enabled: 'true', whisper_model_size: 'base', transcription_cpu_threads: '4', transcription_language_hint: '',
-    generation_provider: 'openai', generation_model: 'gpt-4.1-mini', generation_mode: 'detailed', generation_temperature: '0.2', generation_timeout_seconds: '60', generation_max_tokens: '1200', openai_api_key: '', openai_base_url: 'https://api.openai.com/v1', lmstudio_base_url: 'http://localhost:1234/v1',
+    generation_provider: 'openai', generation_model: 'gpt-4.1-mini', generation_mode: 'detailed', generation_temperature: '0.2', generation_timeout_seconds: '60', generation_max_tokens: '1200', global_prompt_template: 'Convert to {{mode}} article\n{{transcript}}', openai_api_key: '', openai_base_url: 'https://api.openai.com/v1', lmstudio_base_url: 'http://localhost:1234/v1',
     reader_default_theme: 'dark', reader_font_family: 'sans', reader_font_size: '17', reader_line_width: '72',
     scheduler_enabled: 'true', scheduler_default_cadence_minutes: '60', scheduler_concurrency_cap: '2',
   }), []);
@@ -393,9 +396,10 @@ function Settings() {
       title: 'Generation',
       description: 'Model provider, quality mode, and inference limits.',
       fields: [
-        { key: 'generation_provider', label: 'Provider', type: 'select', options: [{ label: 'OpenAI', value: 'openai' }, { label: 'LM Studio', value: 'lmstudio' }] },
+        { key: 'generation_provider', label: 'Provider', type: 'select', options: [{ label: 'No AI (raw transcript)', value: 'raw' }, { label: 'OpenAI', value: 'openai' }, { label: 'LM Studio', value: 'lmstudio' }] },
         { key: 'generation_model', label: 'Model', type: 'text' },
         { key: 'generation_mode', label: 'Generation style', type: 'select', options: [{ label: 'Detailed', value: 'detailed' }, { label: 'Balanced', value: 'balanced' }, { label: 'Brief', value: 'brief' }] },
+        { key: 'global_prompt_template', label: 'Prompt template', type: 'textarea', description: 'Used for transcript-to-article generation. Supports {{mode}} and {{transcript}} placeholders.' },
         { key: 'generation_temperature', label: 'Temperature', type: 'range', min: 0, max: 2, step: 0.1 },
         { key: 'generation_timeout_seconds', label: 'Timeout (seconds)', type: 'range', min: 5, max: 600, step: 5 },
         { key: 'generation_max_tokens', label: 'Max tokens', type: 'range', min: 100, max: 8000, step: 50 },
@@ -464,6 +468,12 @@ function Settings() {
                         max={field.max}
                         step={field.step}
                         onChange={(e) => onFieldChange(field.key, e.target.value)}
+                      />
+                    ) : field.type === 'textarea' ? (
+                      <textarea
+                        value={value}
+                        onChange={(e) => onFieldChange(field.key, e.target.value)}
+                        rows={6}
                       />
                     ) : (
                       <input

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -77,7 +77,14 @@ main { padding: 2rem; }
   box-shadow: 0 16px 45px rgba(1, 4, 12, .45), inset 0 1px 0 rgba(197, 211, 255, .12);
 }
 .card h2, .card h3 { margin-top: 0; }
-.hero { padding: 1.4rem; background: linear-gradient(125deg, rgba(62, 107, 255, 0.33), rgba(132, 85, 218, 0.3)); }
+.hero {
+  padding: 1.4rem;
+  background: linear-gradient(125deg, rgba(62, 107, 255, 0.33), rgba(132, 85, 218, 0.3));
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
 .eyebrow { margin: 0 0 .35rem; font-size: .73rem; letter-spacing: .14em; text-transform: uppercase; color: #d6e3ff; }
 
 .stat { position: relative; overflow: hidden; }
@@ -104,7 +111,7 @@ main { padding: 2rem; }
 .linkish { background: transparent; border: none; color: #a9cbff; padding: 0; font-size: 1rem; }
 .thumb { width: 100%; max-height: 185px; object-fit: cover; border-radius: 12px; margin-bottom: .6rem; border: 1px solid rgba(167, 191, 255, 0.24); }
 
-input, select, button {
+input, select, textarea, button {
   background: var(--surface-strong);
   color: #edf2ff;
   border: 1px solid rgba(165, 189, 255, 0.27);
@@ -113,7 +120,7 @@ input, select, button {
   font: inherit;
 }
 
-input:focus, select:focus, button:focus {
+input:focus, select:focus, textarea:focus, button:focus {
   outline: 2px solid rgba(136, 177, 255, 0.54);
   outline-offset: 1px;
 }
@@ -192,6 +199,11 @@ th { color: #bfd0ff; font-weight: 600; }
 input[type="range"] {
   padding: 0;
   accent-color: #7aa2ff;
+}
+
+textarea {
+  min-height: 8rem;
+  resize: vertical;
 }
 
 .diag-card .label {


### PR DESCRIPTION
### Motivation

- Provide users a way to manually refresh UI data (dashboard, library, reader) without waiting for background jobs.
- Allow customization of the prompt sent to AI providers for transcript→article generation via settings so operators can tweak output style.
- Offer a no-AI option that returns the cleaned raw transcript (timestamps/cue numbers stripped) when users want the original text without LLM processing.

### Description

- Added manual refresh buttons that call `refetch()` in the Dashboard (`Refresh dashboard`), Library (`Refresh results`), and Reader (`Refresh data`) views in `frontend/src/main.tsx`.
- Added settings support for a multiline prompt template with a new `global_prompt_template` default, a `textarea` field type in the settings schema, and a `Prompt template` editor in the Generation group of `frontend/src/main.tsx`.
- Added a `No AI (raw transcript)` provider option to the Generation provider select and wired client UI to accept a `generation_provider` value of `raw` (also accepts `none`/`raw_transcript`).
- Implemented `_clean_raw_transcript` in `backend/app/services/generation.py` (imports `re`) and updated `generate_article` to immediately return the cleaned transcript when provider is `raw`/`none`/`raw_transcript`, removing common timestamps and standalone numeric cues.
- Updated UI styles in `frontend/src/styles.css` to support `textarea` controls and adjust the hero layout for the new dashboard action.

### Testing

- Frontend production build was run with `cd frontend && npm run build` and completed successfully (Vite build succeeded). 
- Backend test suite was run with `cd backend && pytest -q` and all tests passed (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf2df89008331bd5c729475374b06)