### PR TITLE
Add source deletion control to Sources page

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -146,6 +146,10 @@ function Sources() {
     onSuccess: () => { setTitle(''); setUrl(''); queryClient.invalidateQueries({ queryKey: ['sources'] }); },
   });
   const updateSource = useMutation({ mutationFn: async ({ id, payload }: { id: number; payload: Partial<Source> }) => api.patch(`/sources/${id}`, payload), onSuccess: () => queryClient.invalidateQueries({ queryKey: ['sources'] }) });
+  const deleteSource = useMutation({
+    mutationFn: async (id: number) => api.delete(`/sources/${id}`),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['sources'] }),
+  });
 
   return (
     <Page title='Sources'>
@@ -165,6 +169,17 @@ function Sources() {
             <div className='row'>
               <label>State <select value={src.state} onChange={(e) => updateSource.mutate({ id: src.id, payload: { state: e.target.value } })}><option value='enabled'>Enabled</option><option value='paused'>Paused</option><option value='archived'>Archived</option></select></label>
               <label>Cadence <input type='number' defaultValue={src.cadence_minutes} onBlur={(e) => updateSource.mutate({ id: src.id, payload: { cadence_minutes: Number(e.target.value) } })} /></label>
+              <button
+                type='button'
+                onClick={() => {
+                  if (window.confirm(`Remove "${src.title || src.url}" and all imported items?`)) {
+                    deleteSource.mutate(src.id);
+                  }
+                }}
+                disabled={deleteSource.isPending}
+              >
+                Remove source
+              </button>
             </div>
           </article>
         ))}


### PR DESCRIPTION
### Motivation
- Allow users to remove a source (and its imported items) from the UI so source cleanup can be performed without direct DB access.

### Description
- Add a `deleteSource` mutation that calls `DELETE /sources/{id}` and invalidates the `['sources']` query, and add a "Remove source" button to each source card that shows a confirmation prompt and is disabled while the deletion is pending.

### Testing
- Ran `npm run build` from `frontend/` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dafd5978948331b96ebb57f704445b)