### PR TITLE
Fix source pipeline stalling when video duration is unknown

### DIFF
--- a/backend/app/services/youtube.py
+++ b/backend/app/services/youtube.py
@@ -28,9 +28,12 @@ def normalize_source_url(url: str) -> str:
 
 
 def evaluate_video_policy(video: dict, source) -> tuple[bool, str]:
-    if source.skip_shorts and video.get("duration", 0) < 60:
+    duration = video.get("duration")
+    has_duration = duration is not None and duration > 0
+
+    if source.skip_shorts and has_duration and duration < 60:
         return False, "short"
-    if video.get("duration", 0) < source.min_duration_seconds:
+    if has_duration and duration < source.min_duration_seconds:
         return False, "min_duration"
     if source.skip_livestreams and video.get("is_live"):
         return False, "livestream"
@@ -103,7 +106,7 @@ def _parse_atom_feed(feed_xml: str) -> tuple[list[dict], dict]:
                 "url": f"https://www.youtube.com/watch?v={video_id}",
                 "title": title or video_id,
                 "published_at": published_at,
-                "duration": 0,
+                "duration": None,
                 "is_live": False,
             }
         )

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -48,6 +48,12 @@ def test_policy_eval_short_filtered():
     assert not allowed and reason == 'short'
 
 
+def test_policy_eval_unknown_duration_is_not_filtered():
+    source = SimpleNamespace(skip_shorts=True, min_duration_seconds=180, skip_livestreams=True, discovery_mode='latest_n', rolling_window_hours=72)
+    allowed, reason = evaluate_video_policy({'duration': None, 'is_live': False}, source)
+    assert allowed and reason == 'ok'
+
+
 def test_fallback_logic():
     assert should_fallback_to_transcription('transcript_first', False, True)
     assert not should_fallback_to_transcription('disable_fallback', False, True)


### PR DESCRIPTION
### Motivation
- Discovered YouTube Atom feeds do not include duration, and the code treated missing duration as `0`, which caused `skip_shorts` and `min_duration_seconds` filters to exclude every discovered video and leave sources idle.

### Description
- Updated `evaluate_video_policy` in `backend/app/services/youtube.py` to only apply `skip_shorts` and `min_duration_seconds` checks when a positive `duration` is actually known. 
- Changed Atom feed parsing in `_parse_atom_feed` to mark unknown durations as `None` instead of `0` so missing metadata does not trigger duration filters. 
- Added a regression unit test `test_policy_eval_unknown_duration_is_not_filtered` in `backend/tests/test_unit.py` to assert videos with `duration=None` are considered allowed. 

### Testing
- Ran `pytest backend/tests/test_unit.py -q` and all tests passed (6 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbba0771708331a8ae48c2f6d87e63)