### PR TITLE
Auto-refresh sources on creation and improve YouTube feed discovery

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -246,6 +246,7 @@ def create_source(body: SourceCreate, db: Session = Depends(get_db)):
     db.add(src)
     db.commit()
     db.refresh(src)
+    refresh_source(db, src.id)
     return src
 
 

--- a/backend/app/services/youtube.py
+++ b/backend/app/services/youtube.py
@@ -12,6 +12,19 @@ YOUTUBE_FEED_BASE = "https://www.youtube.com/feeds/videos.xml"
 CHANNEL_ID_PATTERN = re.compile(r'"externalId":"(UC[0-9A-Za-z_-]{20,})"')
 
 
+def _http_client() -> httpx.Client:
+    return httpx.Client(
+        timeout=20.0,
+        follow_redirects=True,
+        headers={
+            "User-Agent": (
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+            )
+        },
+    )
+
+
 def normalize_source_url(url: str) -> str:
     url = url.strip()
     if "youtube.com" not in url and "youtu.be" not in url:
@@ -45,33 +58,54 @@ def evaluate_video_policy(video: dict, source) -> tuple[bool, str]:
 
 
 def _extract_channel_id_from_page(source_url: str) -> str:
-    with httpx.Client(timeout=20.0, follow_redirects=True) as client:
+    with _http_client() as client:
         response = client.get(source_url)
         response.raise_for_status()
     match = CHANNEL_ID_PATTERN.search(response.text)
     return match.group(1) if match else ""
 
 
-def _feed_url_from_source_url(source_url: str, channel_id: str = "") -> str:
+def _candidate_feed_urls(source_url: str, channel_id: str = "") -> list[str]:
+    candidates: list[str] = []
     if channel_id:
-        return f"{YOUTUBE_FEED_BASE}?channel_id={channel_id}"
+        return [f"{YOUTUBE_FEED_BASE}?channel_id={channel_id}"]
 
     parsed = urlparse(source_url)
     path = parsed.path.rstrip("/")
 
     if path.startswith("/channel/"):
         source_channel_id = path.split("/", 2)[2]
-        return f"{YOUTUBE_FEED_BASE}?channel_id={source_channel_id}"
+        return [f"{YOUTUBE_FEED_BASE}?channel_id={source_channel_id}"]
     if path.startswith("/@") or path.startswith("/c/") or path.startswith("/user/"):
-        resolved_channel_id = _extract_channel_id_from_page(source_url)
-        if resolved_channel_id:
-            return f"{YOUTUBE_FEED_BASE}?channel_id={resolved_channel_id}"
+        handle_or_name = path.split("/", 2)[1].lstrip("@")
+        if handle_or_name:
+            candidates.append(f"{YOUTUBE_FEED_BASE}?user={handle_or_name}")
+        try:
+            resolved_channel_id = _extract_channel_id_from_page(source_url)
+            if resolved_channel_id:
+                candidates.append(f"{YOUTUBE_FEED_BASE}?channel_id={resolved_channel_id}")
+        except Exception:
+            pass
+        if candidates:
+            return candidates
 
     query = parse_qs(parsed.query)
     if "channel_id" in query and query["channel_id"]:
-        return f"{YOUTUBE_FEED_BASE}?channel_id={query['channel_id'][0]}"
+        return [f"{YOUTUBE_FEED_BASE}?channel_id={query['channel_id'][0]}"]
 
     raise ValueError("Unsupported YouTube source URL format for discovery")
+
+
+def _fetch_feed(source_url: str, channel_id: str = "") -> tuple[list[dict], dict]:
+    for feed_url in _candidate_feed_urls(source_url, channel_id):
+        try:
+            with _http_client() as client:
+                response = client.get(feed_url)
+                response.raise_for_status()
+            return _parse_atom_feed(response.text)
+        except Exception:
+            continue
+    raise ValueError("Unable to fetch feed for source URL")
 
 
 def _parse_atom_feed(feed_xml: str) -> tuple[list[dict], dict]:
@@ -116,12 +150,7 @@ def _parse_atom_feed(feed_xml: str) -> tuple[list[dict], dict]:
 
 def resolve_source_identity(source_url: str) -> dict:
     normalized = normalize_source_url(source_url)
-    feed_url = _feed_url_from_source_url(normalized)
-
-    with httpx.Client(timeout=20.0, follow_redirects=True) as client:
-        response = client.get(feed_url)
-        response.raise_for_status()
-    entries, metadata = _parse_atom_feed(response.text)
+    entries, metadata = _fetch_feed(normalized)
 
     channel_id = metadata.get("channel_id", "")
     canonical_url = f"https://www.youtube.com/channel/{channel_id}" if channel_id else normalized
@@ -136,15 +165,7 @@ def resolve_source_identity(source_url: str) -> dict:
 
 def discover_videos(source) -> list[dict]:
     try:
-        feed_url = _feed_url_from_source_url(source.canonical_url or source.url, source.channel_id or "")
-    except ValueError:
-        return []
-
-    try:
-        with httpx.Client(timeout=20.0, follow_redirects=True) as client:
-            response = client.get(feed_url)
-            response.raise_for_status()
-        videos, _ = _parse_atom_feed(response.text)
+        videos, _ = _fetch_feed(source.canonical_url or source.url, source.channel_id or "")
     except Exception:
         return []
 

--- a/backend/tests/test_integration_additional.py
+++ b/backend/tests/test_integration_additional.py
@@ -61,3 +61,31 @@ def test_source_refresh_deduplicates_and_records_status_timeline(monkeypatch):
         timeline = client.get(f'/api/items/{item_id}/timeline')
         assert timeline.status_code == 200
         assert len(timeline.json()) >= 3
+
+
+def test_create_source_triggers_initial_refresh(monkeypatch):
+    from app.api import routes
+
+    calls: list[int] = []
+
+    monkeypatch.setattr(
+        routes,
+        "resolve_source_identity",
+        lambda url: {
+            "normalized_url": url,
+            "canonical_url": "https://www.youtube.com/channel/UCTESTCHANNEL",
+            "channel_id": "UCTESTCHANNEL",
+            "title": "Economics Explained",
+            "last_discovered_count": 0,
+        },
+    )
+    monkeypatch.setattr(routes, "refresh_source", lambda _db, source_id: calls.append(source_id))
+
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/sources",
+            json={"url": "https://www.youtube.com/@EconomicsExplained", "title": "Economics Explained"},
+        )
+        assert created.status_code == 200
+        source_id = created.json()["id"]
+        assert calls == [source_id]

--- a/backend/tests/test_unit_additional.py
+++ b/backend/tests/test_unit_additional.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 from app.services.ops import redact_secrets
 from app.services.transcript import should_fallback_to_transcription
-from app.services.youtube import evaluate_video_policy
+from app.services.youtube import _candidate_feed_urls, evaluate_video_policy
 
 
 def test_dedup_key_policy_is_source_scoped_example():
@@ -49,3 +49,8 @@ def test_secret_redaction_masks_keys():
     redacted = redact_secrets(text)
     assert "supersecret" not in redacted
     assert "***redacted***" in redacted
+
+
+def test_handle_source_tries_user_feed_before_channel_lookup():
+    urls = _candidate_feed_urls("https://www.youtube.com/@EconomicsExplained")
+    assert urls[0] == "https://www.youtube.com/feeds/videos.xml?user=EconomicsExplained"


### PR DESCRIPTION
### Motivation
- New sources were created but no ingestion ran immediately, leaving the UI showing "1 source, 0 jobs" until the scheduler ticked. 
- YouTube handle/canonical resolution could fail silently or stop discovery when a page fetch failed or when alternate feed forms (`?user=...`) would have worked.

### Description
- Trigger an immediate refresh after creating a source by calling `refresh_source(db, src.id)` at the end of `POST /sources`. 
- Centralize HTTP client settings with a `_http_client()` that sets a browser-like `User-Agent` and consistent timeouts for feed/page requests. 
- Replace single-feed resolution with `_candidate_feed_urls()` that yields `?user=...`, `?channel_id=...` candidates and add `_fetch_feed()` to try candidates until one succeeds. 
- Make page-based channel-id extraction tolerant of fetch failures so discovery will still try other feed candidates. 
- Update `resolve_source_identity` and `discover_videos` to use the new `_fetch_feed()` path and add tests for the regression cases. 

### Testing
- Ran unit and integration test suite with `pytest -q tests/test_integration.py tests/test_integration_additional.py tests/test_unit.py tests/test_unit_additional.py` and all tests passed (`18 passed`).
- Added `test_create_source_triggers_initial_refresh` to `tests/test_integration_additional.py` and `test_handle_source_tries_user_feed_before_channel_lookup` to `tests/test_unit_additional.py` which verify auto-refresh on creation and candidate feed ordering respectively. 
- Manually exercised the API by running `uvicorn app.main:app` and creating `https://www.youtube.com/@EconomicsExplained` to confirm the create -> refresh path executes, but live YouTube fetches were blocked by the environment proxy (`403 Forbidden`) and a Playwright screenshot attempt failed due to missing system library (`libatk-1.0.so.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbbdf2cc4c8331a4c4f0f89bf0672e)