### PR TITLE
Fix YouTube handle source discovery and feed fallback

### DIFF
--- a/backend/app/services/youtube.py
+++ b/backend/app/services/youtube.py
@@ -10,6 +10,13 @@ import httpx
 
 YOUTUBE_FEED_BASE = "https://www.youtube.com/feeds/videos.xml"
 CHANNEL_ID_PATTERN = re.compile(r'"externalId":"(UC[0-9A-Za-z_-]{20,})"')
+CHANNEL_ID_PATTERNS = (
+    CHANNEL_ID_PATTERN,
+    re.compile(r'"channelId":"(UC[0-9A-Za-z_-]{20,})"'),
+    re.compile(r'channelId=("(UC[0-9A-Za-z_-]{20,})"|\'(UC[0-9A-Za-z_-]{20,})\')'),
+    re.compile(r"https://www\.youtube\.com/channel/(UC[0-9A-Za-z_-]{20,})"),
+    re.compile(r"feeds/videos\.xml\?channel_id=(UC[0-9A-Za-z_-]{20,})"),
+)
 
 
 def _http_client() -> httpx.Client:
@@ -61,8 +68,22 @@ def _extract_channel_id_from_page(source_url: str) -> str:
     with _http_client() as client:
         response = client.get(source_url)
         response.raise_for_status()
-    match = CHANNEL_ID_PATTERN.search(response.text)
-    return match.group(1) if match else ""
+    redirected_path = urlparse(str(response.url)).path.rstrip("/")
+    if redirected_path.startswith("/channel/"):
+        redirected_channel_id = redirected_path.split("/", 2)[2]
+        if redirected_channel_id.startswith("UC"):
+            return redirected_channel_id
+
+    for pattern in CHANNEL_ID_PATTERNS:
+        match = pattern.search(response.text)
+        if not match:
+            continue
+        groups = [group for group in match.groups() if group]
+        if groups:
+            return groups[0]
+        if match.group(0).startswith("UC"):
+            return match.group(0)
+    return ""
 
 
 def _candidate_feed_urls(source_url: str, channel_id: str = "") -> list[str]:
@@ -97,14 +118,24 @@ def _candidate_feed_urls(source_url: str, channel_id: str = "") -> list[str]:
 
 
 def _fetch_feed(source_url: str, channel_id: str = "") -> tuple[list[dict], dict]:
-    for feed_url in _candidate_feed_urls(source_url, channel_id):
+    candidate_urls = _candidate_feed_urls(source_url, channel_id)
+    last_error: Exception | None = None
+    for feed_url in candidate_urls:
         try:
             with _http_client() as client:
                 response = client.get(feed_url)
                 response.raise_for_status()
-            return _parse_atom_feed(response.text)
-        except Exception:
+            videos, metadata = _parse_atom_feed(response.text)
+            if videos:
+                return videos, metadata
+            if feed_url.endswith("videos.xml") or "channel_id=" in feed_url:
+                return videos, metadata
+            last_error = ValueError(f"Empty feed response from {feed_url}")
+        except Exception as exc:
+            last_error = exc
             continue
+    if last_error:
+        raise ValueError(f"Unable to fetch feed for source URL: {last_error}") from last_error
     raise ValueError("Unable to fetch feed for source URL")
 
 
@@ -132,7 +163,10 @@ def _parse_atom_feed(feed_xml: str) -> tuple[list[dict], dict]:
             try:
                 published_at = parsedate_to_datetime(published_raw).replace(tzinfo=None)
             except (TypeError, ValueError):
-                published_at = None
+                try:
+                    published_at = datetime.fromisoformat(published_raw.replace("Z", "+00:00")).replace(tzinfo=None)
+                except ValueError:
+                    published_at = None
 
         entries.append(
             {
@@ -164,10 +198,7 @@ def resolve_source_identity(source_url: str) -> dict:
 
 
 def discover_videos(source) -> list[dict]:
-    try:
-        videos, _ = _fetch_feed(source.canonical_url or source.url, source.channel_id or "")
-    except Exception:
-        return []
+    videos, _ = _fetch_feed(source.canonical_url or source.url, source.channel_id or "")
 
     if getattr(source, "discovery_mode", "latest_n") == "since_last_success" and getattr(source, "last_success_at", None):
         videos = [

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -4,7 +4,7 @@ import pytest
 
 from app.services.generation import ProviderConfig, generate_article, render_prompt
 from app.services.transcript import should_fallback_to_transcription
-from app.services.youtube import evaluate_video_policy, normalize_source_url, resolve_source_identity
+from app.services.youtube import discover_videos, evaluate_video_policy, normalize_source_url, resolve_source_identity
 
 
 def test_resolve_source_identity_supports_handle_urls(monkeypatch):
@@ -63,3 +63,40 @@ def test_prompt_and_generation_provider_validation():
     prompt = render_prompt('Mode={{mode}}\n{{transcript}}', 'abc', 'study')
     with pytest.raises(ValueError):
         generate_article('abc', prompt, ProviderConfig(provider='unsupported-provider', model='x'))
+
+
+def test_handle_feed_falls_back_to_channel_id_when_user_feed_is_empty(monkeypatch):
+    channel_id = "UCabcdefghijklmnopqrstuvwxyz123456"
+
+    class FakeResponse:
+        def __init__(self, text):
+            self.text = text
+            self.url = "https://www.youtube.com/@EconomicsExplained"
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url):
+            if "feeds/videos.xml?user=" in url:
+                return FakeResponse("<?xml version='1.0' encoding='UTF-8'?><feed xmlns='http://www.w3.org/2005/Atom' />")
+            if "feeds/videos.xml?channel_id=" in url:
+                return FakeResponse(
+                    f"""<?xml version='1.0' encoding='UTF-8'?><feed xmlns='http://www.w3.org/2005/Atom' xmlns:yt='http://www.youtube.com/xml/schemas/2015'><title>Economics Explained</title><yt:channelId>{channel_id}</yt:channelId><entry><yt:videoId>abc123</yt:videoId><title>Video</title><published>2025-01-01T00:00:00+00:00</published></entry></feed>"""
+                )
+            return FakeResponse(f"<html><body>feeds/videos.xml?channel_id={channel_id}</body></html>")
+
+    monkeypatch.setattr("app.services.youtube.httpx.Client", FakeClient)
+    source = SimpleNamespace(canonical_url="https://www.youtube.com/@EconomicsExplained", url="", channel_id="")
+    videos = discover_videos(source)
+    assert len(videos) == 1
+    assert videos[0]["video_id"] == "abc123"


### PR DESCRIPTION
### Motivation
- Some YouTube handle/custom URLs (e.g. `https://www.youtube.com/@EconomicsExplained`) produced empty `?user=` feeds causing refresh runs to report `fetched=0` even when uploads exist.
- The discovery flow needs more robust channel-id extraction and a fallback to `?channel_id=` feeds so added sources actually enqueue videos.

### Description
- Added multiple extraction patterns in `CHANNEL_ID_PATTERNS` and check for redirected `/channel/UC...` paths in `_extract_channel_id_from_page` to better resolve channel IDs from handle pages.
- Updated `_fetch_feed` to try all candidate feed URLs and fall back from an empty `?user=` response to a discovered `?channel_id=` feed instead of failing early; surface a meaningful error when all candidates fail.
- Improved Atom `published` parsing in `_parse_atom_feed` to accept ISO-8601 timestamps in addition to RFC-style dates.
- Added `test_handle_feed_falls_back_to_channel_id_when_user_feed_is_empty` in `backend/tests/test_unit.py` to reproduce and guard the empty-user-feed -> `channel_id` fallback behavior.

### Testing
- Ran `pytest -q backend/tests/test_unit.py backend/tests/test_unit_additional.py` and all tests passed (`15 passed`).
- The new unit test verifies that a blank `?user=` feed followed by a valid `?channel_id=` feed yields the expected discovered video and it passed.
- Existing unit test coverage for `resolve_source_identity`, `normalize_source_url`, and `evaluate_video_policy` remains green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbca98bef48331a7b7321b17afafbd)