### PR TITLE
Normalize YouTube channel IDs to repair missing UC prefix

### DIFF
--- a/backend/app/services/youtube.py
+++ b/backend/app/services/youtube.py
@@ -19,6 +19,17 @@ CHANNEL_ID_PATTERNS = (
 )
 
 
+def _normalize_channel_id(raw_channel_id: str) -> str:
+    channel_id = (raw_channel_id or "").strip().strip("'\"")
+    if not channel_id:
+        return ""
+    if channel_id.startswith("UC") and re.fullmatch(r"UC[0-9A-Za-z_-]{20,}", channel_id):
+        return channel_id
+    if re.fullmatch(r"[0-9A-Za-z_-]{22,}", channel_id):
+        return f"UC{channel_id}"
+    return channel_id
+
+
 def _http_client() -> httpx.Client:
     return httpx.Client(
         timeout=20.0,
@@ -70,9 +81,11 @@ def _extract_channel_id_from_page(source_url: str) -> str:
         response.raise_for_status()
     redirected_path = urlparse(str(response.url)).path.rstrip("/")
     if redirected_path.startswith("/channel/"):
-        redirected_channel_id = redirected_path.split("/", 2)[2]
-        if redirected_channel_id.startswith("UC"):
-            return redirected_channel_id
+        redirected_parts = redirected_path.split("/")
+        if len(redirected_parts) >= 3:
+            redirected_channel_id = _normalize_channel_id(redirected_parts[2])
+            if redirected_channel_id.startswith("UC"):
+                return redirected_channel_id
 
     for pattern in CHANNEL_ID_PATTERNS:
         match = pattern.search(response.text)
@@ -80,22 +93,24 @@ def _extract_channel_id_from_page(source_url: str) -> str:
             continue
         groups = [group for group in match.groups() if group]
         if groups:
-            return groups[0]
-        if match.group(0).startswith("UC"):
-            return match.group(0)
+            return _normalize_channel_id(groups[0])
+        matched = _normalize_channel_id(match.group(0))
+        if matched.startswith("UC"):
+            return matched
     return ""
 
 
 def _candidate_feed_urls(source_url: str, channel_id: str = "") -> list[str]:
     candidates: list[str] = []
-    if channel_id:
-        return [f"{YOUTUBE_FEED_BASE}?channel_id={channel_id}"]
+    normalized_channel_id = _normalize_channel_id(channel_id)
+    if normalized_channel_id:
+        return [f"{YOUTUBE_FEED_BASE}?channel_id={normalized_channel_id}"]
 
     parsed = urlparse(source_url)
     path = parsed.path.rstrip("/")
 
     if path.startswith("/channel/"):
-        source_channel_id = path.split("/", 2)[2]
+        source_channel_id = _normalize_channel_id(path.split("/", 2)[2])
         return [f"{YOUTUBE_FEED_BASE}?channel_id={source_channel_id}"]
     if path.startswith("/@") or path.startswith("/c/") or path.startswith("/user/"):
         handle_or_name = path.split("/", 2)[1].lstrip("@")
@@ -112,7 +127,8 @@ def _candidate_feed_urls(source_url: str, channel_id: str = "") -> list[str]:
 
     query = parse_qs(parsed.query)
     if "channel_id" in query and query["channel_id"]:
-        return [f"{YOUTUBE_FEED_BASE}?channel_id={query['channel_id'][0]}"]
+        query_channel_id = _normalize_channel_id(query["channel_id"][0])
+        return [f"{YOUTUBE_FEED_BASE}?channel_id={query_channel_id}"]
 
     raise ValueError("Unsupported YouTube source URL format for discovery")
 
@@ -150,7 +166,7 @@ def _parse_atom_feed(feed_xml: str) -> tuple[list[dict], dict]:
     root = ET.fromstring(feed_xml)
     entries: list[dict] = []
     channel_title = root.findtext("atom:title", default="", namespaces=ns)
-    channel_id = root.findtext("yt:channelId", default="", namespaces=ns)
+    channel_id = _normalize_channel_id(root.findtext("yt:channelId", default="", namespaces=ns))
 
     for entry in root.findall("atom:entry", ns):
         video_id = entry.findtext("yt:videoId", default="", namespaces=ns)

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -4,7 +4,13 @@ import pytest
 
 from app.services.generation import ProviderConfig, generate_article, render_prompt
 from app.services.transcript import should_fallback_to_transcription
-from app.services.youtube import discover_videos, evaluate_video_policy, normalize_source_url, resolve_source_identity
+from app.services.youtube import (
+    _candidate_feed_urls,
+    discover_videos,
+    evaluate_video_policy,
+    normalize_source_url,
+    resolve_source_identity,
+)
 
 
 def test_resolve_source_identity_supports_handle_urls(monkeypatch):
@@ -100,3 +106,8 @@ def test_handle_feed_falls_back_to_channel_id_when_user_feed_is_empty(monkeypatc
     videos = discover_videos(source)
     assert len(videos) == 1
     assert videos[0]["video_id"] == "abc123"
+
+
+def test_candidate_feed_urls_repairs_legacy_channel_id_without_uc_prefix():
+    urls = _candidate_feed_urls("https://www.youtube.com/@EconomicsExplained", "Z4AMrDcNrfy3X6nsU8-rPg")
+    assert urls == ["https://www.youtube.com/feeds/videos.xml?channel_id=UCZ4AMrDcNrfy3X6nsU8-rPg"]


### PR DESCRIPTION
### Motivation
- Some stored or parsed YouTube channel IDs can lose the `UC` prefix (e.g. `Z4AMrDcNrfy3X6nsU8-rPg`), causing feed fetches to request an invalid URL and return 404 during refresh. 
- The goal is to automatically normalize and validate channel IDs before building feed URLs so handle-based sources and legacy IDs continue to work.

### Description
- Added `_normalize_channel_id(raw_channel_id: str)` to trim/clean and repair legacy IDs by prepending `UC` when appropriate. 
- Used `_normalize_channel_id` when extracting IDs from redirected `/channel/...` paths, regex matches in page text, feed metadata (`yt:channelId`), query parameters, and stored `channel_id` input to `_candidate_feed_urls`. 
- Hardened redirect parsing for `/channel/...` to validate parts safely before returning an ID. 
- Added regression test `test_candidate_feed_urls_repairs_legacy_channel_id_without_uc_prefix` to assert a legacy ID is converted to `UC...` when forming feed URLs.

### Testing
- Ran unit tests with `pytest -q backend/tests/test_unit.py` and all tests passed (`8 passed`).
- The updated tests include the new regression test which verifies the legacy `channel_id` repair behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf3c875108331bee527feb312eda3)