### PR TITLE
Improve library readability, theming, and reader layout responsiveness

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -51,7 +51,7 @@ DEFAULT_APP_SETTINGS = {
     "openai_base_url": "https://api.openai.com/v1",
     "lmstudio_base_url": "http://localhost:1234/v1",
     "scheduler_enabled": "true",
-    "scheduler_default_cadence_minutes": "60",
+    "scheduler_default_cadence_minutes": "10",
     "scheduler_concurrency_cap": "2",
     "retry_default_max_attempts": "2",
     "retry_default_backoff_minutes": "10",
@@ -72,7 +72,7 @@ DEFAULT_APP_SETTINGS = {
     "log_retention_days": "30",
     "debug_logging": "false",
     "timezone": "UTC",
-    "ui_theme_default": "dark",
+    "ui_theme_default": "system",
     "source_default_discovery_mode": "latest_n",
     "source_default_max_videos": "10",
     "source_default_rolling_window_hours": "72",
@@ -201,7 +201,7 @@ def create_source(body: SourceCreate, db: Session = Depends(get_db)):
         resolved = {"normalized_url": normalized, "canonical_url": normalized, "channel_id": "", "title": ""}
 
     default_cadence_row = db.execute(select(AppSetting).where(AppSetting.key == "scheduler_default_cadence_minutes")).scalar_one_or_none()
-    default_cadence = int(default_cadence_row.value) if default_cadence_row and str(default_cadence_row.value).isdigit() else 60
+    default_cadence = int(default_cadence_row.value) if default_cadence_row and str(default_cadence_row.value).isdigit() else 10
     cadence = body.cadence_minutes or default_cadence
     default_discovery_mode = db.execute(select(AppSetting).where(AppSetting.key == "source_default_discovery_mode")).scalar_one_or_none()
     default_max_videos = db.execute(select(AppSetting).where(AppSetting.key == "source_default_max_videos")).scalar_one_or_none()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -10,7 +10,7 @@ class Settings(BaseSettings):
     openai_base_url: str = "https://api.openai.com/v1"
     lmstudio_base_url: str = "http://localhost:1234/v1"
     scheduler_enabled: bool = True
-    scheduler_default_minutes: int = 60
+    scheduler_default_minutes: int = 10
     max_workers: int = 2
     temp_dir: str = "./tmp"
 

--- a/backend/app/models/entities.py
+++ b/backend/app/models/entities.py
@@ -49,7 +49,7 @@ class Source(Base):
     title: Mapped[str] = mapped_column(String(255), default="")
     metadata_json: Mapped[str] = mapped_column(Text, default="")
     state: Mapped[SourceState] = mapped_column(Enum(SourceState), default=SourceState.enabled)
-    cadence_minutes: Mapped[int] = mapped_column(Integer, default=60)
+    cadence_minutes: Mapped[int] = mapped_column(Integer, default=10)
     discovery_mode: Mapped[str] = mapped_column(String(50), default="latest_n")
     max_videos: Mapped[int] = mapped_column(Integer, default=10)
     rolling_window_hours: Mapped[int] = mapped_column(Integer, default=72)

--- a/backend/app/schemas/source.py
+++ b/backend/app/schemas/source.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 class SourceCreate(BaseModel):
     url: str
     title: str = ""
-    cadence_minutes: int = Field(default=60, ge=5, le=24 * 60)
+    cadence_minutes: int = Field(default=10, ge=5, le=24 * 60)
     discovery_mode: str = "latest_n"
     max_videos: int = Field(default=10, ge=1, le=200)
     rolling_window_hours: int = Field(default=72, ge=1, le=24 * 14)

--- a/backend/app/workers/scheduler.py
+++ b/backend/app/workers/scheduler.py
@@ -41,7 +41,7 @@ def tick_sources():
         sources = db.execute(select(Source).where(Source.state == SourceState.enabled)).scalars().all()
         now = datetime.utcnow()
 
-        default_cadence = max(5, _int_setting(db, "scheduler_default_cadence_minutes", 60))
+        default_cadence = max(5, _int_setting(db, "scheduler_default_cadence_minutes", 10))
         processed = 0
         for src in sources:
             if processed >= cap:
@@ -79,7 +79,7 @@ def scheduler_status() -> dict:
     try:
         enabled = _bool_setting(db, "scheduler_enabled", True)
         cap = _int_setting(db, "scheduler_concurrency_cap", 2)
-        default_cadence = _int_setting(db, "scheduler_default_cadence_minutes", 60)
+        default_cadence = _int_setting(db, "scheduler_default_cadence_minutes", 10)
         return {
             "running": scheduler.running,
             "enabled": enabled,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -43,6 +43,7 @@ type LibraryItem = {
   video_item_id: number;
   video_id?: string;
   video_url?: string;
+  published_at?: string | null;
   source_title: string;
   source_id: number;
   thumbnail_url: string;
@@ -240,12 +241,14 @@ function Library() {
   };
 
   const cards = (items: LibraryItem[]) => (
-    <div className={view === 'list' ? 'stack' : 'grid'}>
+    <div className={view === 'list' ? 'stack library-cards list' : 'grid library-cards'}>
       {items.map((item) => (
         <article key={item.article_id} className='card'>
           {thumbnailFor(item) ? <img className='thumb' src={thumbnailFor(item)} alt={item.title} loading='lazy' /> : null}
           <h3>{item.title}</h3>
-          <p className='muted'>{item.source_title} · v{item.version} · <span className='badge'>{item.transcript_source || 'unknown transcript'}</span></p>
+          <p className='muted'>
+            {item.source_title} · v{item.version} · {item.published_at ? new Date(item.published_at).toLocaleDateString() : 'Unknown publish date'} · <span className='badge'>{item.transcript_source || 'unknown transcript'}</span>
+          </p>
           <p>{item.body_preview || 'No preview available.'}</p>
           <div className='row'>
             <Link to={`/reader/${item.article_id}`}>Open reader</Link>
@@ -265,6 +268,7 @@ function Library() {
       <section className='library-shell'>
         <aside className='card channel-filter'>
           <h3>Channels</h3>
+          <p className='muted'>Filter by source</p>
           {channels.map((channel) => (
             <button
               key={channel}
@@ -275,7 +279,8 @@ function Library() {
                 set('source', channel === 'all' ? '' : channel);
               }}
             >
-              {channel === 'all' ? 'All channels' : channel}
+              <span>{channel === 'all' ? 'All channels' : channel}</span>
+              <span className='muted'>{channel === 'all' ? entries.length : entries.filter((item) => item.source_title === channel).length}</span>
             </button>
           ))}
         </aside>
@@ -300,6 +305,7 @@ function Reader() {
   const articleRef = useRef<HTMLDivElement | null>(null);
   const [selectedVersion, setSelectedVersion] = useState<number | null>(null);
   const [tab, setTab] = useState<'article' | 'transcript'>('article');
+  const [isWideReader, setIsWideReader] = useState(false);
 
   const settings = useQuery({ queryKey: ['settings'], queryFn: async () => (await api.get('/settings')).data as Record<string, string> });
   const detail = useQuery({ queryKey: ['article', id], queryFn: async () => (await api.get(`/articles/${id}`)).data, enabled: Boolean(id) });
@@ -323,20 +329,34 @@ function Reader() {
   const headings = body.split('\n').filter((l: string) => /^#{1,3}\s+/.test(l));
 
   useEffect(() => {
-    const el = articleRef.current;
-    if (!el || !id) return;
+    const updateLayout = () => setIsWideReader(window.matchMedia('(min-width: 1360px) and (min-aspect-ratio: 4/3)').matches);
+    updateLayout();
+    window.addEventListener('resize', updateLayout);
+    return () => window.removeEventListener('resize', updateLayout);
+  }, []);
+
+  useEffect(() => {
+    if (!id) return;
     const onScroll = () => {
-      const total = Math.max(1, el.scrollHeight - el.clientHeight);
-      saveProgress.mutate({ position: Math.round(el.scrollTop), total });
+      const root = document.documentElement;
+      const total = Math.max(1, root.scrollHeight - window.innerHeight);
+      saveProgress.mutate({ position: Math.round(window.scrollY), total });
     };
-    el.addEventListener('scroll', onScroll);
-    return () => el.removeEventListener('scroll', onScroll);
-  }, [id]);
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [id, saveProgress]);
 
   const readerTheme = settings.data?.reader_default_theme || 'dark';
   const readerFont = settings.data?.reader_font_family || 'sans';
   const readerFontSize = Number(settings.data?.reader_font_size || 17);
   const readerWidth = Number(settings.data?.reader_line_width || 72);
+  const chunks = useMemo(() => {
+    const text = tab === 'article' ? (body || 'No content available.') : (transcript.data?.text || 'Transcript unavailable.');
+    if (!isWideReader) return [text];
+    const paragraphs = text.split('\n\n');
+    const midpoint = Math.ceil(paragraphs.length / 2);
+    return [paragraphs.slice(0, midpoint).join('\n\n'), paragraphs.slice(midpoint).join('\n\n')];
+  }, [tab, body, transcript.data?.text, isWideReader]);
 
   return (
     <Page title='Reader'>
@@ -354,10 +374,10 @@ function Reader() {
         {!!headings.length && <details><summary>Headings</summary><ul>{headings.map((h, i) => <li key={i}>{h.replace(/^#{1,3}\s+/, '')}</li>)}</ul></details>}
       </article>
 
-      <article className={`card reader reader-${readerTheme} reader-font-${readerFont}`} style={{ fontSize: `${readerFontSize}px`, maxWidth: `${readerWidth}ch` }}>
+      <article className={`card reader reader-${readerTheme} reader-font-${readerFont} ${isWideReader ? 'reader-spread' : 'reader-single'}`} style={{ fontSize: `${readerFontSize}px`, maxWidth: isWideReader ? '100%' : `${readerWidth}ch` }}>
         <div className='tabs'><button className={tab === 'article' ? 'active' : ''} onClick={() => setTab('article')}>Article</button><button className={tab === 'transcript' ? 'active' : ''} onClick={() => setTab('transcript')}>Transcript</button></div>
         <div ref={articleRef} className='reader-scroll'>
-          {tab === 'article' ? <pre>{body || 'No content available.'}</pre> : <pre>{transcript.data?.text || 'Transcript unavailable.'}</pre>}
+          {chunks.map((chunk, index) => <pre key={index}>{chunk}</pre>)}
         </div>
       </article>
       <article className='card'><h3>Processing timeline</h3><ul className='stack'>{(timeline.data ?? []).map((t) => <li key={t.id}><strong>{t.to_status}</strong> <span className='muted'>{new Date(t.created_at).toLocaleString()}</span>{t.message ? <div className='muted'>{t.message}</div> : null}</li>)}</ul></article>
@@ -396,12 +416,12 @@ function Settings() {
   const queryClient = useQueryClient();
   const [draft, setDraft] = useState<Record<string, string>>({});
   const settingsTemplate = useMemo(() => ({
-    timezone: 'UTC', ui_theme_default: 'dark',
+    timezone: 'UTC', ui_theme_default: 'system',
     source_default_discovery_mode: 'latest_n', source_default_max_videos: '10', source_default_rolling_window_hours: '72', source_default_skip_shorts: 'true', source_default_min_duration_seconds: '180', source_default_dedup_policy: 'source_video_id',
     transcript_languages: 'en', transcript_first: 'true', transcript_fallback_enabled: 'true', whisper_model_size: 'base', transcription_cpu_threads: '4', transcription_language_hint: '',
     generation_provider: 'openai', generation_model: 'gpt-4.1-mini', generation_mode: 'detailed', generation_temperature: '0.2', generation_timeout_seconds: '60', generation_max_tokens: '1200', global_prompt_template: 'Convert to {{mode}} article\n{{transcript}}', openai_api_key: '', openai_base_url: 'https://api.openai.com/v1', lmstudio_base_url: 'http://localhost:1234/v1',
     reader_default_theme: 'dark', reader_font_family: 'sans', reader_font_size: '17', reader_line_width: '72',
-    scheduler_enabled: 'true', scheduler_default_cadence_minutes: '60', scheduler_concurrency_cap: '2',
+    scheduler_enabled: 'true', scheduler_default_cadence_minutes: '10', scheduler_concurrency_cap: '2',
   }), []);
   const settings = useQuery({ queryKey: ['settings'], queryFn: async () => (await api.get('/settings')).data as Record<string, string> });
   const save = useMutation({ mutationFn: async (payload: Record<string, string>) => api.put('/settings', payload), onSuccess: () => queryClient.invalidateQueries({ queryKey: ['settings'] }) });
@@ -414,7 +434,7 @@ function Settings() {
       description: 'Core app and interface defaults.',
       fields: [
         { key: 'timezone', label: 'Timezone', type: 'text', description: 'Used for schedules, logs, and timestamps.' },
-        { key: 'ui_theme_default', label: 'UI theme', type: 'select', options: [{ label: 'Dark', value: 'dark' }, { label: 'Light', value: 'light' }] },
+        { key: 'ui_theme_default', label: 'UI theme', type: 'select', options: [{ label: 'System', value: 'system' }, { label: 'Dark', value: 'dark' }, { label: 'Light', value: 'light' }] },
       ],
     },
     {
@@ -590,6 +610,27 @@ function Logs() {
 
 function Layout() {
   const [navCollapsed, setNavCollapsed] = useState(false);
+  const settings = useQuery({ queryKey: ['settings'], queryFn: async () => (await api.get('/settings')).data as Record<string, string> });
+  const [themeMode, setThemeMode] = useState<'dark' | 'light' | 'system'>('system');
+  useEffect(() => {
+    const preferredTheme = (localStorage.getItem('ui-theme-mode') as 'dark' | 'light' | 'system' | null)
+      || (settings.data?.ui_theme_default as 'dark' | 'light' | 'system' | undefined)
+      || 'system';
+    setThemeMode(preferredTheme);
+  }, [settings.data?.ui_theme_default]);
+
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const applyTheme = () => {
+      const resolved = themeMode === 'system' ? (media.matches ? 'dark' : 'light') : themeMode;
+      document.documentElement.setAttribute('data-theme', resolved);
+    };
+    applyTheme();
+    media.addEventListener('change', applyTheme);
+    localStorage.setItem('ui-theme-mode', themeMode);
+    return () => media.removeEventListener('change', applyTheme);
+  }, [themeMode]);
+
   const links = [
     ['/', 'Home', '🏠'],
     ['/sources', 'Sources', '📺'],
@@ -603,18 +644,32 @@ function Layout() {
   return (
     <div className={`layout ${navCollapsed ? 'nav-collapsed' : ''}`}>
       <aside>
-        <div className='sidebar-top'>
-          {!navCollapsed ? <><h2>ReimagineDoomscrolling</h2><p className='muted product-subtitle'>Reader OS</p></> : null}
-          <button type='button' className='nav-toggle' onClick={() => setNavCollapsed((v) => !v)}>{navCollapsed ? '⮞' : '⮜'}</button>
+        <div className='sidebar-shell'>
+          <div className='sidebar-top'>
+            {!navCollapsed ? <><h2>ReimagineDoomscrolling</h2><p className='muted product-subtitle'>Reader OS</p></> : null}
+            <button type='button' className='nav-toggle' onClick={() => setNavCollapsed((v) => !v)}>{navCollapsed ? '⮞' : '⮜'}</button>
+          </div>
+          <nav>
+            {links.map(([href, label, icon]) => (
+              <NavLink key={href} to={href} className={({ isActive }) => (isActive ? 'active' : '')} end={href === '/'}>
+                <span className='nav-icon'>{icon}</span>
+                {!navCollapsed ? <span>{label}</span> : null}
+              </NavLink>
+            ))}
+          </nav>
+          {!navCollapsed ? (
+            <div className='sidebar-footer'>
+              <label>
+                Theme
+                <select value={themeMode} onChange={(e) => setThemeMode(e.target.value as 'dark' | 'light' | 'system')}>
+                  <option value='system'>System</option>
+                  <option value='dark'>Dark</option>
+                  <option value='light'>Light</option>
+                </select>
+              </label>
+            </div>
+          ) : null}
         </div>
-        <nav>
-          {links.map(([href, label, icon]) => (
-            <NavLink key={href} to={href} className={({ isActive }) => (isActive ? 'active' : '')} end={href === '/'}>
-              <span className='nav-icon'>{icon}</span>
-              {!navCollapsed ? <span>{label}</span> : null}
-            </NavLink>
-          ))}
-        </nav>
       </aside>
       <main>
         <Routes>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -8,6 +8,15 @@
   --muted: #a8b7dc;
   --accent: #7aa2ff;
 }
+:root[data-theme='light'] {
+  color: #1f2a3f;
+  background: #f3f7ff;
+  --surface: rgba(255, 255, 255, 0.95);
+  --surface-strong: rgba(255, 255, 255, 0.98);
+  --border: rgba(84, 110, 177, 0.2);
+  --muted: #5b6786;
+  --accent: #335fcb;
+}
 
 * { box-sizing: border-box; }
 body {
@@ -19,6 +28,12 @@ body {
     radial-gradient(900px 500px at 100% 0%, #6b42be 0%, transparent 50%),
     linear-gradient(180deg, #080c19 0%, #070b17 60%, #05070f 100%);
 }
+:root[data-theme='light'] body {
+  background:
+    radial-gradient(1100px 500px at 0% -10%, #d9e7ff 0%, transparent 55%),
+    radial-gradient(900px 400px at 100% 0%, #e7defd 0%, transparent 45%),
+    linear-gradient(180deg, #f5f8ff 0%, #eef3ff 100%);
+}
 
 a { color: #9ec2ff; }
 
@@ -29,6 +44,14 @@ a { color: #9ec2ff; }
   transition: grid-template-columns .2s ease;
 }
 .layout.nav-collapsed { grid-template-columns: 84px minmax(0, 1fr); }
+.layout.nav-collapsed .sidebar-top {
+  flex-direction: column;
+  align-items: center;
+}
+.layout.nav-collapsed aside nav a {
+  justify-content: center;
+  padding: .65rem;
+}
 
 aside {
   position: sticky;
@@ -39,9 +62,25 @@ aside {
   border-right: 1px solid rgba(136, 164, 237, 0.2);
   backdrop-filter: blur(14px);
 }
+.sidebar-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  gap: .9rem;
+}
 aside h2 { margin: 0; font-size: 1.1rem; letter-spacing: .01em; }
 .product-subtitle { margin: .35rem 0 1rem; text-transform: uppercase; font-size: .72rem; letter-spacing: .13em; }
 aside nav { display: grid; gap: .4rem; }
+.sidebar-footer {
+  margin-top: auto;
+  border-top: 1px solid rgba(167, 191, 255, 0.2);
+  padding-top: .8rem;
+}
+.sidebar-footer label {
+  display: grid;
+  gap: .45rem;
+  font-size: .86rem;
+}
 .sidebar-top {
   display: flex;
   align-items: flex-start;
@@ -96,6 +135,10 @@ main { padding: 2rem; }
   padding: 1.05rem;
   box-shadow: 0 16px 45px rgba(1, 4, 12, .45), inset 0 1px 0 rgba(197, 211, 255, .12);
 }
+:root[data-theme='light'] .card {
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.97), rgba(247, 250, 255, 0.96));
+  box-shadow: 0 12px 35px rgba(26, 44, 92, .08);
+}
 .card h2, .card h3 { margin-top: 0; }
 .hero {
   padding: 1.4rem;
@@ -133,10 +176,13 @@ main { padding: 2rem; }
 .library-shell { display: grid; grid-template-columns: 240px minmax(0, 1fr); gap: 1rem; align-items: flex-start; }
 .library-content { display: grid; gap: 1rem; }
 .library-toolbar { display: grid; gap: .7rem; grid-template-columns: minmax(220px, 1fr) repeat(4, minmax(130px, max-content)); }
-.channel-filter { position: sticky; top: 1rem; display: grid; gap: .5rem; }
+.channel-filter { position: sticky; top: 1rem; display: grid; gap: .45rem; max-height: calc(100vh - 3rem); overflow: auto; }
 .channel-filter h3 { margin-bottom: .3rem; }
 .chip {
   text-align: left;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: .55rem .65rem;
   border-radius: 10px;
   background: rgba(20, 35, 76, 0.8);
@@ -147,6 +193,8 @@ main { padding: 2rem; }
   background: linear-gradient(125deg, rgba(83, 118, 255, 0.45), rgba(140, 91, 221, 0.4));
   border-color: rgba(182, 203, 255, 0.4);
 }
+.library-cards article.card { padding: .95rem; }
+.library-cards.list article.card { max-width: 920px; }
 
 input, select, textarea, button {
   background: var(--surface-strong);
@@ -155,6 +203,12 @@ input, select, textarea, button {
   border-radius: 10px;
   padding: .58rem .75rem;
   font: inherit;
+}
+:root[data-theme='light'] input,
+:root[data-theme='light'] select,
+:root[data-theme='light'] textarea {
+  color: #1f2a3f;
+  border-color: rgba(80, 109, 179, 0.35);
 }
 
 input:focus, select:focus, textarea:focus, button:focus {
@@ -182,11 +236,13 @@ th { color: #bfd0ff; font-weight: 600; }
 .reader .tabs button { box-shadow: none; }
 .reader .tabs button.active { background: linear-gradient(125deg, #3e6bff, #8a5adb); }
 .reader .reader-scroll {
-  max-height: 62vh;
-  overflow: auto;
+  overflow: visible;
   padding: .5rem .2rem .2rem;
-  scrollbar-width: thin;
+  display: grid;
+  gap: 1.5rem;
 }
+.reader.reader-spread .reader-scroll { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 2rem; }
+.reader.reader-spread .reader-scroll pre { border-left: 1px solid rgba(167, 191, 255, .2); padding-left: 1rem; }
 
 .reader-light { background: #f4f6fa; color: #1d2436; }
 .reader-sepia { background: #f5ead6; color: #3e3020; }


### PR DESCRIPTION
### Motivation

- Surface missing metadata and make the library easier to scan by always showing publish dates and making channel selection more informative.
- Fix visual issues with the left (collapsible) panel so elements don't appear to float when expanded or collapsed.
- Give users a simple 3‑way theme control (System / Dark / Light) and make the reader adapt to wide vs. tall screens for better reading ergonomics.
- Reduce the default scheduler/reset interval to a shorter, more responsive default (10 minutes).

### Description

- Frontend: added `published_at` to `LibraryItem` and render a publish date (or a fallback) on every library card, and reworked library card container classes for improved layout (`frontend/src/main.tsx`).
- Frontend: improved channel filter UX by adding a short hint, per-channel item counts, and safer chip layout to avoid floating elements (`frontend/src/main.tsx`, `frontend/src/styles.css`).
- Frontend: implemented a 3‑way theme selector persisted to `localStorage` and respecting `prefers-color-scheme`, plus light-theme CSS token overrides so both dark and light modes are readable (`frontend/src/main.tsx`, `frontend/src/styles.css`).
- Frontend: enhanced reader behavior to detect wide landscape screens and use a two-column spread (two pages side‑by‑side) while keeping single-column flow otherwise, and updated progress saving to follow window scroll for wide layouts (`frontend/src/main.tsx`, `frontend/src/styles.css`).
- Backend & config: changed default scheduler/sources cadence and related defaults from 60 to 10 minutes across runtime defaults, schema-level defaults, and scheduler fallback logic (`backend/app/api/routes.py`, `backend/app/workers/scheduler.py`, `backend/app/core/config.py`, `backend/app/models/entities.py`, `backend/app/schemas/source.py`).

### Testing

- Ran frontend build: `npm run build` in `frontend/` — success (production build completed).
- Ran backend test suite: `pytest -q` in `backend/` — 22 tests passed and 1 integration test failed: `test_settings_source_refresh_completes_without_placeholder_failures` (failure appears unrelated to the UI/layout and cadence default changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc408208c48331a7e2e69f15753bb5)