### PR TITLE
Fix multi-source dedupe behavior and add source-level refresh activity

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -708,6 +708,7 @@ def logs(
     severity: str = '',
     context: str = '',
     q: str = '',
+    source_id: int | None = None,
     db: Session = Depends(get_db),
 ):
     rows = db.execute(select(LogEvent).order_by(LogEvent.created_at.desc()).limit(500)).scalars().all()
@@ -718,6 +719,8 @@ def logs(
         if severity and row.severity.lower() != severity.lower():
             continue
         if context and context.lower() not in sanitized_context.lower():
+            continue
+        if source_id is not None and f"source_id={source_id}" not in sanitized_context:
             continue
         if q and q.lower() not in sanitized_message.lower():
             continue

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -113,10 +113,23 @@ def refresh_source(db, source_id: int):
                 )
                 db.add(item)
             continue
-        exists_stmt = select(VideoItem).where(VideoItem.video_id == raw["video_id"])
-        if source.dedup_policy == "source_video_id":
-            exists_stmt = exists_stmt.where(VideoItem.source_id == source_id)
-        exists = existing_for_video if source.dedup_policy == "source_video_id" else db.execute(exists_stmt).scalar_one_or_none()
+        dedup_policy = (source.dedup_policy or "source_video_id").strip()
+        if dedup_policy == "source_video_id":
+            exists = existing_for_video
+        elif dedup_policy == "title_source":
+            exists = db.execute(
+                select(VideoItem).where(
+                    VideoItem.source_id == source_id,
+                    VideoItem.title == raw["title"],
+                )
+            ).scalar_one_or_none()
+        else:
+            exists = db.execute(
+                select(VideoItem).where(
+                    VideoItem.source_id == source_id,
+                    VideoItem.video_id == raw["video_id"],
+                )
+            ).scalar_one_or_none()
         if exists:
             duplicate_count += 1
             continue

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -67,6 +67,14 @@ type ItemTransition = {
   created_at: string;
 };
 
+type LogEntry = {
+  id: number;
+  severity: string;
+  context: string;
+  message: string;
+  created_at: string;
+};
+
 type SettingField = {
   key: string;
   label: string;
@@ -198,10 +206,55 @@ function Sources() {
 
 function SourceDetail() {
   const { id } = useParams();
+  const sourceId = Number(id);
   const source = useQuery({ queryKey: ['sources'], queryFn: async () => (await api.get('/sources')).data as Source[] });
-  const refresh = useMutation({ mutationFn: async () => api.post(`/sources/${id}/refresh`) });
+  const logs = useQuery({
+    queryKey: ['logs', sourceId],
+    queryFn: async () => (await api.get('/logs', { params: { source_id: sourceId } })).data as LogEntry[],
+    enabled: Number.isFinite(sourceId),
+    refetchInterval: 5000,
+  });
+  const refresh = useMutation({
+    mutationFn: async () => api.post(`/sources/${id}/refresh`),
+    onSuccess: () => {
+      source.refetch();
+      logs.refetch();
+    },
+  });
   const src = (source.data ?? []).find((s) => String(s.id) === id);
-  return <Page title='Source detail'><article className='card'><h2>{src?.title ?? 'Missing source'}</h2><p>{src?.url}</p><button onClick={() => refresh.mutate()}>Refresh now</button></article></Page>;
+  const activeLogs = (logs.data ?? []).filter((entry) => entry.context.includes(`source_id=${sourceId}`));
+  const latestLogs = activeLogs.slice(0, 10);
+
+  return (
+    <Page title='Source detail'>
+      <article className='card stack'>
+        <h2>{src?.title ?? 'Missing source'}</h2>
+        <p>{src?.url}</p>
+        <div className='row'>
+          <button onClick={() => refresh.mutate()} disabled={refresh.isPending || !src}>
+            {refresh.isPending ? 'Refreshing…' : 'Refresh now'}
+          </button>
+          <button onClick={() => logs.refetch()} disabled={logs.isFetching}>Reload activity</button>
+        </div>
+        <p className='muted'>
+          {refresh.isPending ? 'Refresh is running. Activity updates every 5 seconds.' : 'Tip: keep this page open to watch refresh progress.'}
+        </p>
+      </article>
+      <article className='card'>
+        <h3>Latest activity</h3>
+        <ul className='stack'>
+          {latestLogs.length === 0 && <li className='muted'>No source-specific logs yet.</li>}
+          {latestLogs.map((entry) => (
+            <li key={entry.id}>
+              <strong>[{entry.severity}]</strong> <span className='muted'>{new Date(entry.created_at).toLocaleString()}</span>
+              <br />
+              {entry.context}: {entry.message}
+            </li>
+          ))}
+        </ul>
+      </article>
+    </Page>
+  );
 }
 
 function Library() {


### PR DESCRIPTION
### Motivation
- Users adding a second source were seeing very few items imported because deduplication performed global `video_id` checks across sources and incorrectly suppressed new items. 
- There was no easy way to observe what a source refresh was doing because logs were only exposed globally, so debugging progress/failures was hard.

### Description
- Change dedupe logic in the refresh pipeline to respect the configured policy by using a source-scoped check: `source_video_id` uses the existing `existing_for_video`, `title_source` checks `(VideoItem.source_id, VideoItem.title)`, and unknown policies fallback to a safe source-scoped `video_id` check (`backend/app/services/pipeline.py`).
- Add a `source_id` query parameter to the `/logs` endpoint so callers can request source-specific activity streams (`backend/app/api/routes.py`).
- Enhance the Source Detail UI to show refresh visibility and live activity by polling `/logs?source_id=...` every 5s, display recent source-specific log entries, and show a `Refreshing…` state and manual `Reload activity` control (`frontend/src/main.tsx`).

### Testing
- Ran unit tests with `pytest -q tests/test_unit.py tests/test_unit_additional.py` and they all passed. 
- Built the frontend with `npm run build` successfully. 
- Ran full test suite with `pytest -q` and observed one failing integration test: `tests/test_integration.py::test_settings_source_refresh_completes_without_placeholder_failures` (pre-existing/integration-level failure), while other tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc51ea5f888331b8456acbf169765f)