### PR TITLE
Improve yt-dlp fallback retries and error diagnostics

### DIFF
--- a/backend/app/services/transcript.py
+++ b/backend/app/services/transcript.py
@@ -67,18 +67,47 @@ def transcribe_audio_locally(
 ) -> tuple[str, dict]:
     with tempfile.TemporaryDirectory(prefix="reimagine_transcribe_") as temp_dir:
         audio_path = os.path.join(temp_dir, "audio.%(ext)s")
-        cmd = [
-            yt_dlp_command,
-            "-f",
-            "bestaudio/best",
-            "-x",
-            "--audio-format",
-            "mp3",
-            "-o",
-            audio_path,
-            video_url,
+        yt_dlp_attempts = [
+            [
+                yt_dlp_command,
+                "--no-playlist",
+                "-f",
+                "bestaudio/best",
+                "-x",
+                "--audio-format",
+                "mp3",
+                "-o",
+                audio_path,
+                video_url,
+            ],
+            [
+                yt_dlp_command,
+                "--no-playlist",
+                "--extractor-args",
+                "youtube:player_client=android,web",
+                "-f",
+                "bestaudio/best",
+                "-x",
+                "--audio-format",
+                "mp3",
+                "-o",
+                audio_path,
+                video_url,
+            ],
         ]
-        subprocess.run(cmd, check=True, capture_output=True, text=True)
+        yt_dlp_error = ""
+        for cmd in yt_dlp_attempts:
+            try:
+                subprocess.run(cmd, check=True, capture_output=True, text=True)
+                yt_dlp_error = ""
+                break
+            except subprocess.CalledProcessError as exc:
+                stderr = (exc.stderr or "").strip()
+                stdout = (exc.stdout or "").strip()
+                output = stderr or stdout or str(exc)
+                yt_dlp_error = output[-1200:]
+        if yt_dlp_error:
+            raise RuntimeError(f"yt-dlp failed after {len(yt_dlp_attempts)} attempts: {yt_dlp_error}")
         mp3_path = os.path.join(temp_dir, "audio.mp3")
         normalized_path = os.path.join(temp_dir, "audio.normalized.wav")
         subprocess.run(

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from app.services.generation import ProviderConfig, generate_article, render_prompt
-from app.services.transcript import should_fallback_to_transcription
+from app.services.transcript import should_fallback_to_transcription, transcribe_audio_locally
 from app.services.youtube import (
     _candidate_feed_urls,
     discover_videos,
@@ -111,3 +111,50 @@ def test_handle_feed_falls_back_to_channel_id_when_user_feed_is_empty(monkeypatc
 def test_candidate_feed_urls_repairs_legacy_channel_id_without_uc_prefix():
     urls = _candidate_feed_urls("https://www.youtube.com/@EconomicsExplained", "Z4AMrDcNrfy3X6nsU8-rPg")
     assert urls == ["https://www.youtube.com/feeds/videos.xml?channel_id=UCZ4AMrDcNrfy3X6nsU8-rPg"]
+
+
+def test_transcribe_audio_locally_retries_yt_dlp_with_extractor_args(monkeypatch):
+    class FakeSegment:
+        text = "hello world"
+
+    class FakeModel:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def transcribe(self, _path):
+            return [FakeSegment()], {}
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, check, capture_output, text):
+        calls.append(cmd)
+        if cmd[0] == "yt-dlp" and "--extractor-args" not in cmd:
+            raise __import__("subprocess").CalledProcessError(returncode=1, cmd=cmd, stderr="primary failed")
+        return None
+
+    monkeypatch.setattr("app.services.transcript.WhisperModel", FakeModel)
+    monkeypatch.setattr("app.services.transcript.subprocess.run", fake_run)
+
+    transcript, meta = transcribe_audio_locally("https://www.youtube.com/watch?v=abc123")
+    assert transcript == "hello world"
+    assert meta["transcription_seconds"] >= 0
+    yt_dlp_calls = [cmd for cmd in calls if cmd[0] == "yt-dlp"]
+    assert len(yt_dlp_calls) == 2
+    assert "--extractor-args" in yt_dlp_calls[1]
+
+
+def test_transcribe_audio_locally_surfaces_yt_dlp_error_details(monkeypatch):
+    class FakeModel:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    def fake_run(cmd, check, capture_output, text):
+        if cmd[0] == "yt-dlp":
+            raise __import__("subprocess").CalledProcessError(returncode=1, cmd=cmd, stderr="Sign in to confirm you’re not a bot")
+        return None
+
+    monkeypatch.setattr("app.services.transcript.WhisperModel", FakeModel)
+    monkeypatch.setattr("app.services.transcript.subprocess.run", fake_run)
+
+    with pytest.raises(RuntimeError, match="yt-dlp failed after 2 attempts"):
+        transcribe_audio_locally("https://www.youtube.com/watch?v=abc123")


### PR DESCRIPTION
### Motivation
- Make local audio download more resilient to known YouTube extraction edge-cases and avoid playlist resolution side-effects.
- Surface actionable error context when `yt-dlp` fails so failures in logs/jobs are easier to triage.

### Description
- Update `transcribe_audio_locally` in `backend/app/services/transcript.py` to run multiple `yt-dlp` attempts, adding `--no-playlist` and a second attempt with `--extractor-args youtube:player_client=android,web` to improve success rates.
- Capture `yt-dlp` `stderr`/`stdout` for each attempt and raise a `RuntimeError` with trimmed diagnostic output when all attempts fail.
- Add unit tests in `backend/tests/test_unit.py` that validate the retry behavior and that errors from `yt-dlp` are surfaced when both attempts fail.

### Testing
- Ran unit tests with `cd backend && pytest -q tests/test_unit.py` and all tests passed (`10 passed`).
- New tests specifically cover `transcribe_audio_locally` retry and error-surfacing behavior and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc56ea95148331b518dadcb052c38d)