### PR TITLE
Remove generation_mode, increase token limits, sanitize model output, and update prompts/UI

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -58,11 +58,10 @@ DEFAULT_APP_SETTINGS = {
     "retry_default_backoff_multiplier": "2",
     "generation_provider": "openai",
     "generation_model": "gpt-4.1-mini",
-    "generation_mode": "detailed",
     "generation_temperature": "0.2",
     "generation_timeout_seconds": "60",
-    "generation_max_tokens": "1200",
-    "global_prompt_template": "Convert to {{mode}} article\n{{transcript}}",
+    "generation_max_tokens": "30000",
+    "global_prompt_template": "Convert the transcript into a polished article.\n\n{{transcript}}",
     "transcript_languages": "en",
     "retain_failed_audio": "false",
     "delete_audio_after_success": "true",
@@ -133,7 +132,6 @@ def settings_schema():
         "generation": [
             "generation_provider",
             "generation_model",
-            "generation_mode",
             "generation_temperature",
             "generation_timeout_seconds",
             "generation_max_tokens",
@@ -404,8 +402,7 @@ def generation_prompt_preview(payload: dict, db: Session = Depends(get_db)):
     template_setting = db.execute(select(AppSetting).where(AppSetting.key == "global_prompt_template")).scalar_one_or_none()
     template = payload.get("template") or (template_setting.value if template_setting else DEFAULT_APP_SETTINGS["global_prompt_template"])
     transcript = payload.get("transcript", "")
-    mode = payload.get("mode") or "detailed"
-    return {"prompt": render_prompt(template, transcript, mode)}
+    return {"prompt": render_prompt(template, transcript, "")}
 
 
 @router.post('/generation/test-prompt')
@@ -413,9 +410,8 @@ def generation_test_prompt(payload: dict, db: Session = Depends(get_db)):
     transcript = payload.get("transcript", "")
     if not transcript.strip():
         raise HTTPException(400, "transcript is required")
-    mode = payload.get("mode") or "detailed"
     template = payload.get("template") or DEFAULT_APP_SETTINGS["global_prompt_template"]
-    prompt = render_prompt(template, transcript, mode)
+    prompt = render_prompt(template, transcript, "")
     rows = db.execute(select(AppSetting)).scalars().all()
     settings_map = {r.key: r.value for r in rows}
     body = generate_article(
@@ -426,7 +422,7 @@ def generation_test_prompt(payload: dict, db: Session = Depends(get_db)):
             model=settings_map.get("generation_model", "gpt-4.1-mini"),
             temperature=float(settings_map.get("generation_temperature", "0.2")),
             timeout_seconds=float(settings_map.get("generation_timeout_seconds", "60")),
-            max_tokens=int(settings_map.get("generation_max_tokens", "1200")),
+            max_tokens=int(settings_map.get("generation_max_tokens", "30000")),
             openai_api_key=settings_map.get("openai_api_key", ""),
             openai_base_url=settings_map.get("openai_base_url", ""),
             lmstudio_base_url=settings_map.get("lmstudio_base_url", ""),

--- a/backend/app/schemas/common.py
+++ b/backend/app/schemas/common.py
@@ -21,8 +21,7 @@ class SettingsPatch(BaseModel):
     retry_default_backoff_multiplier: int | None = Field(default=None, ge=1, le=8)
     generation_temperature: float | None = Field(default=None, ge=0, le=2)
     generation_timeout_seconds: int | None = Field(default=None, ge=5, le=300)
-    generation_max_tokens: int | None = Field(default=None, ge=64, le=12000)
-    generation_mode: str | None = None
+    generation_max_tokens: int | None = Field(default=None, ge=64, le=30000)
     global_prompt_template: str | None = None
     retain_failed_audio: bool | None = None
     delete_audio_after_success: bool | None = None

--- a/backend/app/services/generation.py
+++ b/backend/app/services/generation.py
@@ -46,7 +46,15 @@ def _chat_completion(base_url: str, api_key: str, model: str, prompt: str, tempe
         "model": model,
         "temperature": temperature,
         "messages": [
-            {"role": "system", "content": f"You convert transcripts into polished reading articles. {_mode_instruction(prompt)}"},
+            {
+                "role": "system",
+                "content": (
+                    "You convert transcripts into polished reading articles. "
+                    "Return only the final article body. Do not include reasoning, chain-of-thought, thinking process, "
+                    "analysis notes, scratchpad text, or XML tags like <think>. "
+                    f"{_mode_instruction(prompt)}"
+                ),
+            },
             {"role": "user", "content": prompt},
         ],
         "max_tokens": max_tokens,
@@ -57,7 +65,14 @@ def _chat_completion(base_url: str, api_key: str, model: str, prompt: str, tempe
         response.raise_for_status()
 
     body = response.json()
-    return body["choices"][0]["message"]["content"].strip()
+    raw = body["choices"][0]["message"]["content"].strip()
+    return _strip_reasoning_artifacts(raw)
+
+
+def _strip_reasoning_artifacts(text: str) -> str:
+    cleaned = re.sub(r"<think>.*?</think>", "", text, flags=re.IGNORECASE | re.DOTALL)
+    cleaned = re.sub(r"```(?:thinking|reasoning)[\s\S]*?```", "", cleaned, flags=re.IGNORECASE)
+    return cleaned.strip()
 
 
 def _clean_raw_transcript(transcript: str) -> str:

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -252,13 +252,12 @@ def process_video_item(db, item_id: int):
         _set_item_status(db, item, ItemStatus.generation_started)
         provider_name = _get_setting(db, "generation_provider", "openai")
         model_name = _get_setting(db, "generation_model", "gpt-4.1-mini")
-        mode_name = _get_setting(db, "generation_mode", "detailed")
-        global_template = _get_setting(db, "global_prompt_template", "Convert to {{mode}} article\n{{transcript}}")
+        global_template = _get_setting(db, "global_prompt_template", "Convert the transcript into a polished article.\n\n{{transcript}}")
         timeout_seconds = float(_get_setting(db, "generation_timeout_seconds", "60"))
         temperature = float(_get_setting(db, "generation_temperature", "0.2"))
-        max_tokens = int(_get_setting(db, "generation_max_tokens", "1200"))
+        max_tokens = int(_get_setting(db, "generation_max_tokens", "30000"))
         prompt_template = source.prompt_override if source and source.prompt_override else global_template
-        prompt = render_prompt(prompt_template, text, mode_name)
+        prompt = render_prompt(prompt_template, text, "")
         body = generate_article(
             text,
             prompt,
@@ -285,7 +284,7 @@ def process_video_item(db, item_id: int):
             version_num = article.latest_version + 1
             article.latest_version = version_num
 
-        db.add(ArticleVersion(article_id=article.id, version=version_num, mode=mode_name, prompt_snapshot=prompt, body=body))
+        db.add(ArticleVersion(article_id=article.id, version=version_num, mode="default", prompt_snapshot=prompt, body=body))
         _set_item_status(db, item, ItemStatus.generation_completed)
         _set_item_status(db, item, ItemStatus.published)
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -472,7 +472,7 @@ function Settings() {
     timezone: 'UTC', ui_theme_default: 'system',
     source_default_discovery_mode: 'latest_n', source_default_max_videos: '10', source_default_rolling_window_hours: '72', source_default_skip_shorts: 'true', source_default_min_duration_seconds: '180', source_default_dedup_policy: 'source_video_id',
     transcript_languages: 'en', transcript_first: 'true', transcript_fallback_enabled: 'true', whisper_model_size: 'base', transcription_cpu_threads: '4', transcription_language_hint: '',
-    generation_provider: 'openai', generation_model: 'gpt-4.1-mini', generation_mode: 'detailed', generation_temperature: '0.2', generation_timeout_seconds: '60', generation_max_tokens: '1200', global_prompt_template: 'Convert to {{mode}} article\n{{transcript}}', openai_api_key: '', openai_base_url: 'https://api.openai.com/v1', lmstudio_base_url: 'http://localhost:1234/v1',
+    generation_provider: 'openai', generation_model: 'gpt-4.1-mini', generation_temperature: '0.2', generation_timeout_seconds: '60', generation_max_tokens: '30000', global_prompt_template: 'Convert the transcript into a polished article.\n\n{{transcript}}', openai_api_key: '', openai_base_url: 'https://api.openai.com/v1', lmstudio_base_url: 'http://localhost:1234/v1',
     reader_default_theme: 'dark', reader_font_family: 'sans', reader_font_size: '17', reader_line_width: '72',
     scheduler_enabled: 'true', scheduler_default_cadence_minutes: '10', scheduler_concurrency_cap: '2',
   }), []);
@@ -516,15 +516,14 @@ function Settings() {
     },
     {
       title: 'Generation',
-      description: 'Model provider, quality mode, and inference limits.',
+      description: 'Model provider and inference limits.',
       fields: [
         { key: 'generation_provider', label: 'Provider', type: 'select', options: [{ label: 'No AI (raw transcript)', value: 'raw' }, { label: 'OpenAI', value: 'openai' }, { label: 'LM Studio', value: 'lmstudio' }] },
         { key: 'generation_model', label: 'Model', type: 'text' },
-        { key: 'generation_mode', label: 'Generation style', type: 'select', options: [{ label: 'Detailed', value: 'detailed' }, { label: 'Balanced', value: 'balanced' }, { label: 'Brief', value: 'brief' }] },
-        { key: 'global_prompt_template', label: 'Prompt template', type: 'textarea', description: 'Used for transcript-to-article generation. Supports {{mode}} and {{transcript}} placeholders.' },
+        { key: 'global_prompt_template', label: 'Prompt template', type: 'textarea', description: 'Used for transcript-to-article generation. Supports {{transcript}} placeholder.' },
         { key: 'generation_temperature', label: 'Temperature', type: 'range', min: 0, max: 2, step: 0.1 },
         { key: 'generation_timeout_seconds', label: 'Timeout (seconds)', type: 'range', min: 5, max: 600, step: 5 },
-        { key: 'generation_max_tokens', label: 'Max tokens', type: 'range', min: 100, max: 8000, step: 50 },
+        { key: 'generation_max_tokens', label: 'Max tokens', type: 'range', min: 100, max: 30000, step: 100 },
         { key: 'openai_base_url', label: 'OpenAI base URL', type: 'url' },
         { key: 'openai_api_key', label: 'OpenAI API key', type: 'password' },
         { key: 'lmstudio_base_url', label: 'LM Studio base URL', type: 'url' },


### PR DESCRIPTION
### Motivation
- Simplify generation flow by removing the legacy `generation_mode` concept and its placeholder from templates.
- Allow much larger model outputs by increasing `generation_max_tokens` and exposing the higher limit in schema and UI.
- Prevent leakage of chain-of-thought or debugging artifacts from model responses by instructing the model to return only final article text and stripping common reasoning artifacts.

### Description
- Removed use of `generation_mode` across API routes, pipeline, schemas, and frontend defaults, and stopped passing a mode into `render_prompt`; stored article versions with `mode="default"` instead of a mode name.
- Replaced the default `global_prompt_template` with a simpler prompt that no longer relies on `{{mode}}`, and adjusted API endpoints (`/generation/prompt-preview`, `/generation/test-prompt`) to stop accepting `mode`.
- Raised `generation_max_tokens` default and validation limits to `30000` in `DEFAULT_APP_SETTINGS`, `SettingsPatch` schema, and the frontend settings template and slider range.
- Strengthened `_chat_completion` in `services/generation.py` by adding a stricter system message that asks the model to return only the final article and adding `_strip_reasoning_artifacts` to remove `<think>` blocks and fenced reasoning sections from model output.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4c8e40948331aa9c1088a88be2c6)