### PR TITLE
Fix SQLite lock contention via WAL and busy timeout

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,9 +1,36 @@
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 
 from app.core.config import settings
 
-engine = create_engine(settings.database_url, future=True)
+
+def _is_sqlite_url(url: str) -> bool:
+    return url.startswith("sqlite")
+
+
+engine_kwargs = {"future": True}
+
+if _is_sqlite_url(settings.database_url):
+    engine_kwargs["connect_args"] = {
+        "check_same_thread": False,
+        "timeout": 30,
+    }
+
+engine = create_engine(settings.database_url, **engine_kwargs)
+
+
+if _is_sqlite_url(settings.database_url):
+    @event.listens_for(Engine, "connect")
+    def _configure_sqlite_connection(dbapi_connection, _connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA synchronous=NORMAL")
+        cursor.execute("PRAGMA busy_timeout=30000")
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
 
 

--- a/backend/tests/test_db_session_sqlite.py
+++ b/backend/tests/test_db_session_sqlite.py
@@ -1,0 +1,15 @@
+from sqlalchemy import text
+
+from app.db.session import SessionLocal
+
+
+def test_sqlite_pragmas_configured_for_concurrency():
+    db = SessionLocal()
+    try:
+        busy_timeout = db.execute(text("PRAGMA busy_timeout")).scalar_one()
+        journal_mode = db.execute(text("PRAGMA journal_mode")).scalar_one()
+
+        assert busy_timeout >= 30000
+        assert str(journal_mode).lower() == "wal"
+    finally:
+        db.close()


### PR DESCRIPTION
### Motivation

- 遇到并发/后台任务访问本地 SQLite 时频繁的 `sqlite3.OperationalError: database is locked`，需要使本地 DB 在多线程/后台调度下更耐用并等待锁而不是立即失败。 

### Description

- 在 `backend/app/db/session.py` 中检测 SQLite URL，并在创建引擎时为 SQLite 设置 `connect_args`（`check_same_thread=False` 和 `timeout=30`）。
- 为 SQLite 连接添加 `@event.listens_for(Engine, "connect")` 钩子，执行 PRAGMA 配置：`journal_mode=WAL`、`synchronous=NORMAL`、`busy_timeout=30000` 和 `foreign_keys=ON`。
- 保持 `SessionLocal` 和 `get_db()` 行为不变以兼容现有代码路径。 
- 新增回归测试 `backend/tests/test_db_session_sqlite.py`，验证 `PRAGMA busy_timeout` 与 `PRAGMA journal_mode` 已正确生效。 

### Testing

- 运行单元/回归相关测试：`cd backend && pytest -q tests/test_db_session_sqlite.py tests/test_integration_additional.py`，所有这部分测试通过（`4 passed`）。
- 运行完整测试套件：`cd backend && pytest -q`，当前仓库存在一个与本次改动无关的既有失败：`tests/test_integration.py::test_settings_source_refresh_completes_without_placeholder_failures`，该失败在本次改动前后均存在。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de568348d08331a0a1d4ba68fe33af)