### PR TITLE
Fix SQLite lock during source creation and set min-duration range to 2–10 minutes

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,8 +1,8 @@
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Response
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.db.session import get_db
+from app.db.session import SessionLocal, get_db
 from app.models.entities import (
     AppSetting,
     Article,
@@ -44,6 +44,15 @@ from app.services.youtube import normalize_source_url, resolve_source_identity
 from app.workers.scheduler import scheduler_status
 
 router = APIRouter()
+
+
+def _refresh_source_in_background(source_id: int):
+    db = SessionLocal()
+    try:
+        refresh_source(db, source_id)
+    finally:
+        db.close()
+
 DEFAULT_APP_SETTINGS = {
     "ffmpeg_path": "",
     "yt_dlp_path": "",
@@ -182,7 +191,7 @@ def list_sources(db: Session = Depends(get_db)):
 
 
 @router.post('/sources', response_model=SourceOut)
-def create_source(body: SourceCreate, db: Session = Depends(get_db)):
+def create_source(body: SourceCreate, background_tasks: BackgroundTasks, db: Session = Depends(get_db)):
     try:
         normalized = normalize_source_url(body.url)
     except ValueError as e:
@@ -244,7 +253,7 @@ def create_source(body: SourceCreate, db: Session = Depends(get_db)):
     db.add(src)
     db.commit()
     db.refresh(src)
-    refresh_source(db, src.id)
+    background_tasks.add_task(_refresh_source_in_background, src.id)
     return src
 
 

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -48,7 +48,8 @@ def refresh_source(db, source_id: int):
         return
     run = RefreshRun(source_id=source_id, status="running", summary="")
     db.add(run)
-    db.flush()
+    db.commit()
+    db.refresh(run)
 
     fetched_count = 0
     filtered_count = 0
@@ -145,6 +146,7 @@ def refresh_source(db, source_id: int):
         db.add(item)
         db.flush()
         _set_item_status(db, item, ItemStatus.queued)
+        db.commit()
         enqueued_count += 1
         try:
             process_video_item(db, item.id)

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -497,7 +497,7 @@ function Settings() {
         { key: 'source_default_discovery_mode', label: 'Discovery mode', type: 'select', options: [{ label: 'Latest N', value: 'latest_n' }, { label: 'Rolling window', value: 'rolling_window' }] },
         { key: 'source_default_max_videos', label: 'Max videos per run', type: 'range', min: 1, max: 100, step: 1 },
         { key: 'source_default_rolling_window_hours', label: 'Rolling window (hours)', type: 'range', min: 1, max: 336, step: 1 },
-        { key: 'source_default_min_duration_seconds', label: 'Min duration (seconds)', type: 'range', min: 0, max: 3600, step: 30 },
+        { key: 'source_default_min_duration_seconds', label: 'Min duration (seconds)', type: 'range', min: 120, max: 600, step: 60, description: 'Range: 2 to 10 minutes.' },
         { key: 'source_default_skip_shorts', label: 'Skip shorts', type: 'select', options: [{ label: 'Enabled', value: 'true' }, { label: 'Disabled', value: 'false' }] },
         { key: 'source_default_dedup_policy', label: 'De-duplication', type: 'select', options: [{ label: 'Source video ID', value: 'source_video_id' }, { label: 'Title + source', value: 'title_source' }] },
       ],


### PR DESCRIPTION
### Motivation
- Creating a source triggered an inline `refresh_source` that held a request-bound DB session while the refresh ran, which caused `sqlite3.OperationalError: database is locked` under concurrency. 
- Long-running flush/transaction windows inside the refresh path increased lock contention during writes. 
- The UI needed the minimum source time-limit control to reflect a 2–10 minute range rather than the previous second-based wide range.

### Description
- Move the initial source refresh out of the request transaction by scheduling `_refresh_source_in_background` via FastAPI `BackgroundTasks` and using a separate `SessionLocal` for the background work. 
- Reduce lock hold time in `refresh_source` by committing the newly-created `RefreshRun` immediately (`db.commit()` + `db.refresh(run)`) instead of leaving a flushed transaction open. 
- Commit queued-item state earlier in `refresh_source` by committing after marking an item queued, so processing-heavy work runs outside long write transactions. 
- Update the frontend settings slider for `source_default_min_duration_seconds` to `min: 120, max: 600, step: 60` and add a human hint to represent a 2–10 minute range.

### Testing
- Ran `cd backend && pytest -q tests/test_db_session_sqlite.py tests/test_integration_additional.py::test_create_source_triggers_initial_refresh tests/test_integration_additional.py::test_source_refresh_deduplicates_and_records_status_timeline` and all tests passed. 
- The SQLite concurrency unit test `test_sqlite_pragmas_configured_for_concurrency` passed validating busy timeout and WAL mode. 
- The integration tests exercising `POST /api/sources` and refresh behavior passed, confirming background refresh is queued and initial-refresh hook is invoked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5c3b7104833186078c4b4a452c80)