### PR TITLE
Fix source removal error toast formatting

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -17,6 +17,7 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
 import ReactMarkdown from 'react-markdown';
 import { api } from './lib/api';
 import './styles.css';
@@ -99,6 +100,13 @@ const NotificationContext = React.createContext<{ notify: (message: string, kind
 
 function useNotifications() {
   return React.useContext(NotificationContext);
+}
+
+function getApiErrorMessage(error: unknown, fallback: string) {
+  const detail = (error as AxiosError<{ detail?: unknown }>)?.response?.data?.detail;
+  if (typeof detail !== 'string') return fallback;
+  const cleaned = detail.replace(/\\n/g, '\n').trim();
+  return cleaned || fallback;
 }
 
 function Page({ title, children }: { title: string; children: React.ReactNode }) {
@@ -186,7 +194,7 @@ function Sources() {
   const deleteSource = useMutation({
     mutationFn: async (id: number) => api.delete(`/sources/${id}`),
     onSuccess: () => { queryClient.invalidateQueries({ queryKey: ['sources'] }); notify('Source removed.'); },
-    onError: () => notify('Could not remove source.', 'error'),
+    onError: (error) => notify(getApiErrorMessage(error, 'Could not remove source.'), 'error'),
   });
 
   return (


### PR DESCRIPTION
### Motivation
- When a source deletion failed the UI showed a literal `\n` prefix (e.g. `\nCould not remove source.`), so users couldn't see the backend-provided error message cleanly.

### Description
- Add a small helper `getApiErrorMessage` in `frontend/src/main.tsx` that extracts `response.data.detail` from an `AxiosError`, converts escaped newlines (`\\n`) into real newlines, and trims whitespace.
- Use that helper in the source deletion mutation's `onError` handler so the toast shows a cleaned backend message while preserving the original fallback text (`Could not remove source.`).
- Import the `AxiosError` type and update `frontend/src/main.tsx` accordingly.

### Testing
- Ran `npm run build` in `frontend`, which failed due to Vite being unable to resolve `react-markdown` (module resolution issue unrelated to this change), so the build did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de86afab988331bf3c80663237d9b5)