### PR TITLE
Fix source deletion cleanup for dependent records

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -10,9 +10,12 @@ from app.models.entities import (
     ItemStatus,
     Collection,
     CollectionArticle,
+    ItemStatusTransition,
     Job,
+    JobItem,
     LogEvent,
     ReadingProgress,
+    RefreshRun,
     Source,
     SourceState,
     Transcript,
@@ -294,7 +297,16 @@ def delete_source(source_id: int, db: Session = Depends(get_db)):
     src = db.get(Source, source_id)
     if not src:
         raise HTTPException(404)
+    source_job_ids = [
+        row[0]
+        for row in db.execute(select(Job.id).where(Job.source_id == source_id)).all()
+    ]
     video_ids = [row[0] for row in db.execute(select(VideoItem.id).where(VideoItem.source_id == source_id)).all()]
+    video_job_ids = [
+        row[0]
+        for row in db.execute(select(Job.id).where(Job.video_item_id.in_(video_ids))).all()
+    ] if video_ids else []
+    job_ids = list({*source_job_ids, *video_job_ids})
     article_ids = [row[0] for row in db.execute(select(Article.id).where(Article.video_item_id.in_(video_ids))).all()] if video_ids else []
     if article_ids:
         db.query(CollectionArticle).filter(CollectionArticle.article_id.in_(article_ids)).delete(synchronize_session=False)
@@ -302,9 +314,13 @@ def delete_source(source_id: int, db: Session = Depends(get_db)):
         db.query(ArticleVersion).filter(ArticleVersion.article_id.in_(article_ids)).delete(synchronize_session=False)
         db.query(Article).filter(Article.id.in_(article_ids)).delete(synchronize_session=False)
     if video_ids:
+        db.query(ItemStatusTransition).filter(ItemStatusTransition.video_item_id.in_(video_ids)).delete(synchronize_session=False)
         db.query(Transcript).filter(Transcript.video_item_id.in_(video_ids)).delete(synchronize_session=False)
         db.query(Job).filter(Job.video_item_id.in_(video_ids)).delete(synchronize_session=False)
         db.query(VideoItem).filter(VideoItem.id.in_(video_ids)).delete(synchronize_session=False)
+    if job_ids:
+        db.query(JobItem).filter(JobItem.job_id.in_(job_ids)).delete(synchronize_session=False)
+    db.query(RefreshRun).filter(RefreshRun.source_id == source_id).delete(synchronize_session=False)
     db.query(Job).filter(Job.source_id == source_id).delete()
     db.delete(src)
     db.commit()

--- a/backend/tests/test_integration_additional.py
+++ b/backend/tests/test_integration_additional.py
@@ -89,3 +89,30 @@ def test_create_source_triggers_initial_refresh(monkeypatch):
         assert created.status_code == 200
         source_id = created.json()["id"]
         assert calls == [source_id]
+
+
+def test_delete_source_removes_dependent_refresh_runs_and_job_items():
+    from app.db.session import SessionLocal
+    from app.models.entities import Job, JobItem, RefreshRun, Source
+
+    with TestClient(app) as client:
+        created = client.post("/api/sources", json={"url": "https://youtube.com/channel/delete-me", "title": "Delete me"})
+        assert created.status_code == 200
+        source_id = created.json()["id"]
+
+        db = SessionLocal()
+        try:
+            src = db.get(Source, source_id)
+            assert src is not None
+            job = Job(type="refresh_source", status="queued", source_id=source_id)
+            db.add(job)
+            db.flush()
+            db.add(JobItem(job_id=job.id, status="queued"))
+            db.add(RefreshRun(source_id=source_id, status="done", summary="ok"))
+            db.commit()
+        finally:
+            db.close()
+
+        deleted = client.delete(f"/api/sources/{source_id}")
+        assert deleted.status_code == 200
+        assert deleted.json() == {"deleted": True}


### PR DESCRIPTION
### Motivation
- Deleting a source sometimes failed or hung due to leftover dependent rows (jobs, job items, refresh runs, and item status transitions) that violated foreign-key constraints. 
- The intent is to make `DELETE /api/sources/{id}` reliably remove all related records so the UI "Remove source" action no longer errors after a delay.

### Description
- Collected relevant job IDs before removing rows and removed dependent `JobItem` rows referencing those jobs to avoid FK errors during job deletion in `backend/app/api/routes.py`. 
- Also delete `ItemStatusTransition` rows related to the source's `VideoItem`s and remove any `RefreshRun` rows for the source; added the necessary imports (`ItemStatusTransition`, `JobItem`, `RefreshRun`) at the top of the routes module. 
- Kept the existing cleanup for `Article`, `ArticleVersion`, `Transcript`, `Job`, `VideoItem`, `CollectionArticle`, and `ReadingProgress`, and ensured deletion ordering is safe. 
- Added an integration regression test `test_delete_source_removes_dependent_refresh_runs_and_job_items` in `backend/tests/test_integration_additional.py` that seeds a `Job`, `JobItem`, and `RefreshRun` for a source and asserts `DELETE /api/sources/{id}` succeeds.

### Testing
- Ran `pytest backend/tests/test_integration_additional.py::test_delete_source_removes_dependent_refresh_runs_and_job_items -q` and it passed. 
- Ran `pytest backend/tests/test_integration_additional.py -q` and the full file passed (4 tests) with warnings only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dec6dd6bf0833199c2e108d2ce8048)