### PR TITLE
Fix source deletion FK ordering to avoid foreign-key constraint failures

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -313,13 +313,14 @@ def delete_source(source_id: int, db: Session = Depends(get_db)):
         db.query(ReadingProgress).filter(ReadingProgress.article_id.in_(article_ids)).delete(synchronize_session=False)
         db.query(ArticleVersion).filter(ArticleVersion.article_id.in_(article_ids)).delete(synchronize_session=False)
         db.query(Article).filter(Article.id.in_(article_ids)).delete(synchronize_session=False)
+    if job_ids:
+        db.query(JobItem).filter(JobItem.job_id.in_(job_ids)).delete(synchronize_session=False)
     if video_ids:
+        db.query(JobItem).filter(JobItem.video_item_id.in_(video_ids)).delete(synchronize_session=False)
         db.query(ItemStatusTransition).filter(ItemStatusTransition.video_item_id.in_(video_ids)).delete(synchronize_session=False)
         db.query(Transcript).filter(Transcript.video_item_id.in_(video_ids)).delete(synchronize_session=False)
         db.query(Job).filter(Job.video_item_id.in_(video_ids)).delete(synchronize_session=False)
         db.query(VideoItem).filter(VideoItem.id.in_(video_ids)).delete(synchronize_session=False)
-    if job_ids:
-        db.query(JobItem).filter(JobItem.job_id.in_(job_ids)).delete(synchronize_session=False)
     db.query(RefreshRun).filter(RefreshRun.source_id == source_id).delete(synchronize_session=False)
     db.query(Job).filter(Job.source_id == source_id).delete()
     db.delete(src)

--- a/backend/tests/test_integration_additional.py
+++ b/backend/tests/test_integration_additional.py
@@ -116,3 +116,32 @@ def test_delete_source_removes_dependent_refresh_runs_and_job_items():
         deleted = client.delete(f"/api/sources/{source_id}")
         assert deleted.status_code == 200
         assert deleted.json() == {"deleted": True}
+
+
+def test_delete_source_removes_job_items_before_video_jobs():
+    from app.db.session import SessionLocal
+    from app.models.entities import Job, JobItem, Source, VideoItem
+
+    with TestClient(app) as client:
+        created = client.post("/api/sources", json={"url": "https://youtube.com/channel/delete-video-jobs", "title": "Delete video jobs"})
+        assert created.status_code == 200
+        source_id = created.json()["id"]
+
+        db = SessionLocal()
+        try:
+            src = db.get(Source, source_id)
+            assert src is not None
+            video = VideoItem(source_id=source_id, video_id="abc123xyz99", url="https://youtu.be/abc123xyz99")
+            db.add(video)
+            db.flush()
+            job = Job(type="generate_article", status="queued", video_item_id=video.id)
+            db.add(job)
+            db.flush()
+            db.add(JobItem(job_id=job.id, video_item_id=video.id, status="queued"))
+            db.commit()
+        finally:
+            db.close()
+
+        deleted = client.delete(f"/api/sources/{source_id}")
+        assert deleted.status_code == 200
+        assert deleted.json() == {"deleted": True}


### PR DESCRIPTION
### Motivation
- Deleting a `Source` could fail with `FOREIGN KEY constraint failed` when `VideoItem`-scoped `Job` rows had dependent `JobItem` rows because deletion ordering removed parent rows before children.

### Description
- Reordered deletion logic in `backend/app/api/routes.py` to delete `JobItem` rows for `job_ids` and `video_ids` before deleting related `Job` and `VideoItem` rows.
- Added explicit deletion of `JobItem` rows that reference `video_item_id` to cover video-scoped jobs and prevent FK violations.
- Added an integration test `test_delete_source_removes_job_items_before_video_jobs` in `backend/tests/test_integration_additional.py` that reproduces the failing shape and verifies `DELETE /api/sources/{id}` succeeds.

### Testing
- Ran `pytest -q backend/tests/test_integration_additional.py -k delete_source` and observed `2 passed, 3 deselected`, confirming the fix and related deletion tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dec9056d58833186a53d345db5c767)