### PR TITLE
Add fallback feed discovery when persisted YouTube channel IDs are stale

### DIFF
--- a/backend/app/services/youtube.py
+++ b/backend/app/services/youtube.py
@@ -102,24 +102,32 @@ def _extract_channel_id_from_page(source_url: str) -> str:
 
 def _candidate_feed_urls(source_url: str, channel_id: str = "") -> list[str]:
     candidates: list[str] = []
+    seen: set[str] = set()
+
+    def add_candidate(url: str) -> None:
+        if url and url not in seen:
+            seen.add(url)
+            candidates.append(url)
+
     normalized_channel_id = _normalize_channel_id(channel_id)
     if normalized_channel_id:
-        return [f"{YOUTUBE_FEED_BASE}?channel_id={normalized_channel_id}"]
+        add_candidate(f"{YOUTUBE_FEED_BASE}?channel_id={normalized_channel_id}")
 
     parsed = urlparse(source_url)
     path = parsed.path.rstrip("/")
 
     if path.startswith("/channel/"):
         source_channel_id = _normalize_channel_id(path.split("/", 2)[2])
-        return [f"{YOUTUBE_FEED_BASE}?channel_id={source_channel_id}"]
+        add_candidate(f"{YOUTUBE_FEED_BASE}?channel_id={source_channel_id}")
+        return candidates
     if path.startswith("/@") or path.startswith("/c/") or path.startswith("/user/"):
         handle_or_name = path.split("/", 2)[1].lstrip("@")
         if handle_or_name:
-            candidates.append(f"{YOUTUBE_FEED_BASE}?user={handle_or_name}")
+            add_candidate(f"{YOUTUBE_FEED_BASE}?user={handle_or_name}")
         try:
             resolved_channel_id = _extract_channel_id_from_page(source_url)
             if resolved_channel_id:
-                candidates.append(f"{YOUTUBE_FEED_BASE}?channel_id={resolved_channel_id}")
+                add_candidate(f"{YOUTUBE_FEED_BASE}?channel_id={resolved_channel_id}")
         except Exception:
             pass
         if candidates:
@@ -128,7 +136,8 @@ def _candidate_feed_urls(source_url: str, channel_id: str = "") -> list[str]:
     query = parse_qs(parsed.query)
     if "channel_id" in query and query["channel_id"]:
         query_channel_id = _normalize_channel_id(query["channel_id"][0])
-        return [f"{YOUTUBE_FEED_BASE}?channel_id={query_channel_id}"]
+        add_candidate(f"{YOUTUBE_FEED_BASE}?channel_id={query_channel_id}")
+        return candidates
 
     raise ValueError("Unsupported YouTube source URL format for discovery")
 

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -110,7 +110,39 @@ def test_handle_feed_falls_back_to_channel_id_when_user_feed_is_empty(monkeypatc
 
 def test_candidate_feed_urls_repairs_legacy_channel_id_without_uc_prefix():
     urls = _candidate_feed_urls("https://www.youtube.com/@EconomicsExplained", "Z4AMrDcNrfy3X6nsU8-rPg")
-    assert urls == ["https://www.youtube.com/feeds/videos.xml?channel_id=UCZ4AMrDcNrfy3X6nsU8-rPg"]
+    assert urls[0] == "https://www.youtube.com/feeds/videos.xml?channel_id=UCZ4AMrDcNrfy3X6nsU8-rPg"
+
+
+def test_candidate_feed_urls_falls_back_when_persisted_channel_id_is_stale(monkeypatch):
+    class FakeResponse:
+        def __init__(self, text):
+            self.text = text
+            self.url = "https://www.youtube.com/@EconomicsExplained"
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url):
+            return FakeResponse("<html><body>feeds/videos.xml?channel_id=UCNEWCHANNELID123456789012</body></html>")
+
+    monkeypatch.setattr("app.services.youtube.httpx.Client", FakeClient)
+
+    urls = _candidate_feed_urls("https://www.youtube.com/@EconomicsExplained", "UCSTALECHANNELID123456789012")
+    assert urls == [
+        "https://www.youtube.com/feeds/videos.xml?channel_id=UCSTALECHANNELID123456789012",
+        "https://www.youtube.com/feeds/videos.xml?user=EconomicsExplained",
+        "https://www.youtube.com/feeds/videos.xml?channel_id=UCNEWCHANNELID123456789012",
+    ]
 
 
 def test_transcribe_audio_locally_retries_yt_dlp_with_extractor_args(monkeypatch):


### PR DESCRIPTION
### Motivation
- Some sources store an outdated YouTube `channel_id` which can cause feed refreshes to fail with `404`; the discovery logic should keep the persisted candidate but still try URL-derived fallbacks.
- Duplicate feed URLs should not be retried repeatedly during discovery.

### Description
- Added a de-duplicating helper (`seen` + `add_candidate`) in `_candidate_feed_urls` to avoid duplicate feed candidates and to append candidates instead of returning early. 
- Preserve a normalized persisted `channel_id` candidate while continuing to build and return additional candidates derived from the source path (e.g. `user=`) and the page-resolved channel id (`channel_id=`). 
- Adjusted the channel-path branch to append the channel candidate and return the list of candidates for consistent ordering. 
- Relaxed an existing test assertion and added `test_candidate_feed_urls_falls_back_when_persisted_channel_id_is_stale` in `backend/tests/test_unit.py` to simulate a stale persisted channel id and verify the fallback candidate order.

### Testing
- Ran `pytest -q backend/tests/test_unit.py -q` and all unit tests in that file passed (`...........`).
- No other automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dedc001ca883319591e1c3b75686f0)