### PR TITLE
Add configurable backend address and connection test in frontend

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,2 +1,45 @@
 import axios from 'axios';
-export const api = axios.create({ baseURL: 'http://localhost:8000/api' });
+
+const BACKEND_ADDRESS_STORAGE_KEY = 'rd_backend_address';
+const DEFAULT_API_BASE_URL = 'http://localhost:8000/api';
+
+function buildApiBaseUrl(address: string) {
+  const trimmed = address.trim();
+  if (!trimmed) throw new Error('Backend address is required.');
+
+  const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  const withoutTrailingSlash = withProtocol.replace(/\/+$/, '');
+  return withoutTrailingSlash.endsWith('/api') ? withoutTrailingSlash : `${withoutTrailingSlash}/api`;
+}
+
+function getStoredApiBaseUrl() {
+  if (typeof window === 'undefined') return DEFAULT_API_BASE_URL;
+  const stored = window.localStorage.getItem(BACKEND_ADDRESS_STORAGE_KEY);
+  if (!stored) return DEFAULT_API_BASE_URL;
+  try {
+    return buildApiBaseUrl(stored);
+  } catch {
+    return DEFAULT_API_BASE_URL;
+  }
+}
+
+export const api = axios.create({ baseURL: getStoredApiBaseUrl() });
+
+export function getBackendAddress() {
+  const baseUrl = api.defaults.baseURL ?? DEFAULT_API_BASE_URL;
+  return baseUrl.endsWith('/api') ? baseUrl.slice(0, -4) : baseUrl;
+}
+
+export function setBackendAddress(address: string) {
+  const nextBaseUrl = buildApiBaseUrl(address);
+  api.defaults.baseURL = nextBaseUrl;
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(BACKEND_ADDRESS_STORAGE_KEY, getBackendAddress());
+  }
+  return nextBaseUrl;
+}
+
+export async function testBackendConnection(address: string) {
+  const client = axios.create({ baseURL: buildApiBaseUrl(address), timeout: 5000 });
+  await client.get('/health');
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -19,7 +19,7 @@ import {
 } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 import ReactMarkdown from 'react-markdown';
-import { api } from './lib/api';
+import { api, getBackendAddress, setBackendAddress, testBackendConnection } from './lib/api';
 import './styles.css';
 
 const qc = new QueryClient();
@@ -544,6 +544,7 @@ function CollectionsPage() {
 function Settings() {
   const queryClient = useQueryClient();
   const [draft, setDraft] = useState<Record<string, string>>({});
+  const [backendAddress, setBackendAddressInput] = useState(getBackendAddress);
   const { notify } = useNotifications();
   const settingsTemplate = useMemo(() => ({
     timezone: 'UTC',
@@ -563,6 +564,11 @@ function Settings() {
       notify('Settings saved.');
     },
     onError: () => notify('Settings failed to save.', 'error'),
+  });
+  const testBackend = useMutation({
+    mutationFn: async (address: string) => testBackendConnection(address),
+    onSuccess: () => notify('Backend connection succeeded.'),
+    onError: (error) => notify(getApiErrorMessage(error, 'Could not reach backend address.'), 'error'),
   });
 
   const merged = { ...settingsTemplate, ...(settings.data ?? {}), ...draft };
@@ -652,6 +658,40 @@ function Settings() {
 
   return (
     <Page title='Settings'>
+      <article className='card'>
+        <h2>Backend connection</h2>
+        <p className='muted'>Set the backend host used by this frontend (for example, 192.168.1.10:8000).</p>
+        <div className='row'>
+          <input
+            type='text'
+            value={backendAddress}
+            onChange={(e) => setBackendAddressInput(e.target.value)}
+            placeholder='localhost:8000'
+          />
+          <button
+            type='button'
+            onClick={() => testBackend.mutate(backendAddress)}
+            disabled={testBackend.isPending}
+          >
+            {testBackend.isPending ? 'Testing…' : 'Test connection'}
+          </button>
+          <button
+            type='button'
+            onClick={() => {
+              try {
+                const nextAddress = setBackendAddress(backendAddress);
+                setBackendAddressInput(getBackendAddress());
+                queryClient.invalidateQueries();
+                notify(`Backend address saved: ${nextAddress}`);
+              } catch {
+                notify('Invalid backend address. Please use host:port or a full URL.', 'error');
+              }
+            }}
+          >
+            Save backend address
+          </button>
+        </div>
+      </article>
       <article className='card settings-toolbar'>
         <div>
           <h2>System settings</h2>


### PR DESCRIPTION
### Motivation
- Allow the frontend to connect to a backend running on a remote host or server IP:port instead of the hardcoded `http://localhost:8000/api` endpoint. 
- Provide users an easy way to point the UI at a deployed backend and verify connectivity before saving the change. 
- Persist the chosen backend address so the frontend continues to use it across reloads.

### Description
- Added `frontend/src/lib/api.ts` which normalizes user input to a valid `/api` base URL via `buildApiBaseUrl`, persists the raw backend address to `localStorage`, exposes `getBackendAddress` and `setBackendAddress`, and adds `testBackendConnection` to probe `GET /health` against a candidate endpoint. 
- Replaced the previous static `api` base URL with an `axios` instance created from `getStoredApiBaseUrl` so the app will use the persisted address when present. 
- Updated the Settings UI (`frontend/src/main.tsx`) to add a new "Backend connection" card where users can enter an address, run `Test connection`, and `Save backend address`; saving applies the endpoint to the API client and invalidates queries so data reloads from the new backend. 
- Wired a `testBackend` mutation to call `testBackendConnection` and show success/error notifications using the existing notification system.

### Testing
- Built the frontend production bundle with `npm --prefix frontend run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df816632908331a61f3290bb2c54af)