### PR TITLE
Fix remote frontend/backend connectivity for LAN access

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,14 +9,37 @@ from app.db.session import engine
 from app.workers.scheduler import start_scheduler
 
 app = FastAPI(title='ReimagineDoomscrolling API')
-allowed_origins = [origin.strip() for origin in os.getenv('CORS_ORIGINS', 'http://localhost:5173,http://127.0.0.1:5173').split(',') if origin.strip()]
-app.add_middleware(CORSMiddleware, allow_origins=allowed_origins, allow_methods=['*'], allow_headers=['*'])
+
+# By default, allow localhost and any IPv4-address origins so frontend dev servers
+# running on other machines in the same network can call this backend.
+def _parse_cors_origins():
+    raw = os.getenv('CORS_ORIGINS', 'http://localhost:5173,http://127.0.0.1:5173')
+    return [origin.strip() for origin in raw.split(',') if origin.strip()]
+
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_parse_cors_origins(),
+    allow_origin_regex=r"^https?://((localhost)|(127\.0\.0\.1)|((\d{1,3}\.){3}\d{1,3}))(:\d+)?$",
+    allow_methods=['*'],
+    allow_headers=['*'],
+)
 
 
 @app.on_event('startup')
 def startup():
     Base.metadata.create_all(bind=engine)
     start_scheduler()
+
+
+@app.get('/')
+def root():
+    return {'status': 'ok', 'api': '/api'}
+
+
+@app.get('/health')
+def health():
+    return {'status': 'ok'}
 
 
 app.include_router(router, prefix='/api')

--- a/backend/tests/test_integration_additional.py
+++ b/backend/tests/test_integration_additional.py
@@ -145,3 +145,14 @@ def test_delete_source_removes_job_items_before_video_jobs():
         deleted = client.delete(f"/api/sources/{source_id}")
         assert deleted.status_code == 200
         assert deleted.json() == {"deleted": True}
+
+
+def test_root_and_unprefixed_health_endpoints_are_available_for_connectivity_checks():
+    with TestClient(app) as client:
+        root = client.get('/')
+        assert root.status_code == 200
+        assert root.json() == {'status': 'ok', 'api': '/api'}
+
+        health = client.get('/health')
+        assert health.status_code == 200
+        assert health.json() == {'status': 'ok'}


### PR DESCRIPTION
### Motivation
- Frontend instances running on other machines in the same LAN were blocked from calling the backend due to too-restrictive CORS handling. 
- Hitting the backend at the bare host:port returned `404`, making quick connectivity checks confusing.

### Description
- Broadened CORS handling by adding a helper `_parse_cors_origins()` and an `allow_origin_regex` that permits `localhost`, `127.0.0.1`, and arbitrary IPv4 addresses with optional ports while still honoring a `CORS_ORIGINS` override in the environment (`backend/app/main.py`).
- Added top-level `GET /` and `GET /health` endpoints that return simple status payloads to allow direct host:port connectivity probes (`backend/app/main.py`).
- Added an integration test `test_root_and_unprefixed_health_endpoints_are_available_for_connectivity_checks` to `backend/tests/test_integration_additional.py` to verify the new endpoints.

### Testing
- Ran `pytest backend/tests/test_integration_additional.py -q` which passed (6 tests, 3 warnings). 
- Ran `pytest backend/tests/test_integration.py -q` which failed due to an unrelated existing `refresh_source` failure assertion in `test_settings_source_refresh_completes_without_placeholder_failures` and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df84beae188331b3f4782cc77ba2c2)