### PR TITLE
Compact library cards and fix sidebar toggle layout

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -353,7 +353,6 @@ function Library() {
             <span className='badge'>Category: {item.video_category || 'Unrated'}</span>
             <span className='badge'>Score: {item.quality_score ?? 0}</span>
           </p>
-          <p>{item.body_preview || 'No preview available.'}</p>
           <div className='row'>
             <Link to={`/reader/${item.article_id}`}>Open reader</Link>
             <button onClick={() => markRead.mutate({ articleId: item.article_id, isRead: !item.is_read })}>{item.is_read ? 'Mark unread' : 'Mark read'}</button>
@@ -372,7 +371,7 @@ function Library() {
       <section className='library-shell'>
         <aside className='card channel-filter'>
           <h3>Channels</h3>
-          <p className='muted'>Filter by source</p>
+          <p className='muted channel-filter-label'>Filter by source</p>
           {channels.map((channel) => (
             <button
               key={channel}
@@ -842,7 +841,12 @@ function Layout() {
         <aside>
         <div className='sidebar-shell'>
           <div className='sidebar-top'>
-            {!navCollapsed ? <><h2>ReimagineDoomscrolling</h2><p className='muted product-subtitle'>Reader OS</p></> : null}
+            {!navCollapsed ? (
+              <div className='sidebar-brand'>
+                <h2>ReimagineDoomscrolling</h2>
+                <p className='muted product-subtitle'>Reader OS</p>
+              </div>
+            ) : null}
             <button type='button' className='nav-toggle' onClick={() => setNavCollapsed((v) => !v)}>{navCollapsed ? '⮞' : '⮜'}</button>
           </div>
           <nav>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -27,8 +27,8 @@ a { color: #fff; }
 }
 .layout.nav-collapsed { grid-template-columns: 84px minmax(0, 1fr); }
 .layout.nav-collapsed .sidebar-top {
-  flex-direction: column;
-  align-items: center;
+  grid-template-columns: 1fr;
+  justify-items: center;
 }
 .layout.nav-collapsed aside nav a {
   justify-content: center;
@@ -63,11 +63,17 @@ aside nav { display: grid; gap: .4rem; }
   font-size: .86rem;
 }
 .sidebar-top {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: .45rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: .6rem;
   margin-bottom: 1rem;
+}
+.sidebar-brand {
+  min-width: 0;
+}
+aside h2 {
+  overflow-wrap: anywhere;
 }
 .nav-toggle {
   padding: .35rem .5rem;
@@ -75,6 +81,9 @@ aside nav { display: grid; gap: .4rem; }
   box-shadow: none;
   background: #000;
   border: 1px solid var(--border);
+  align-self: start;
+  justify-self: end;
+  flex-shrink: 0;
 }
 aside nav a {
   text-decoration: none;
@@ -153,19 +162,40 @@ main { padding: 2rem; }
 .library-shell { display: grid; grid-template-columns: 240px minmax(0, 1fr); gap: 1rem; align-items: flex-start; }
 .library-content { display: grid; gap: 1rem; }
 .library-toolbar { display: grid; gap: .7rem; grid-template-columns: minmax(220px, 1fr) repeat(4, minmax(130px, max-content)); }
-.channel-filter { position: sticky; top: 1rem; display: grid; gap: .45rem; max-height: calc(100vh - 3rem); overflow: auto; }
+.channel-filter {
+  position: sticky;
+  top: 1rem;
+  display: grid;
+  gap: .35rem;
+  max-height: calc(100vh - 3rem);
+  overflow: auto;
+  align-content: start;
+}
 .channel-filter h3 { margin-bottom: .3rem; }
+.channel-filter-label {
+  margin: 0 0 .2rem;
+  font-size: .8rem;
+  line-height: 1.2;
+}
 .chip {
   text-align: left;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: .55rem .65rem;
+  gap: .45rem;
+  min-height: 2.1rem;
+  padding: .42rem .6rem;
   border-radius: 10px;
   background: rgba(20, 35, 76, 0.8);
   background: #000;
   border: 1px solid var(--border);
   box-shadow: none;
+}
+.chip span:first-child {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .chip.active {
   background: #111;


### PR DESCRIPTION
### Motivation
- Make library cards more consistent and compact by removing the large content preview. 
- Keep the sidebar collapse/minimize button anchored inside the sidebar so it no longer floats and blocks content. 
- Reduce the vertical footprint of the channels/filter UI so the channel list and the "Filter by source" label take a small, equal area.

### Description
- Remove the `body_preview` paragraph from each library card in `frontend/src/main.tsx` so card heights are consistent. 
- Wrap the app title/subtitle in a `sidebar-brand` container in `frontend/src/main.tsx` so the collapse toggle can be positioned reliably next to the brand. 
- Update sidebar CSS in `frontend/src/styles.css` to use a grid-based `.sidebar-top` layout and adjust `.layout.nav-collapsed .sidebar-top` so the toggle stays inside the sidebar. 
- Tighten channel filter styling in `frontend/src/styles.css` by reducing `.channel-filter` gap, adding `.channel-filter-label`, shrinking `.chip` padding/min-height, and adding truncation for long channel names with `.chip span:first-child`.

### Testing
- Ran the frontend production build with `npm --prefix frontend run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df86e382c883318bdab69d7b3adea6)