### PR TITLE
Add readeros.duckdns.org to backend CORS defaults

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,10 @@ app = FastAPI(title='ReimagineDoomscrolling API')
 # By default, allow localhost and any IPv4-address origins so frontend dev servers
 # running on other machines in the same network can call this backend.
 def _parse_cors_origins():
-    raw = os.getenv('CORS_ORIGINS', 'http://localhost:5173,http://127.0.0.1:5173')
+    raw = os.getenv(
+        'CORS_ORIGINS',
+        'http://localhost:5173,http://127.0.0.1:5173,https://readeros.duckdns.org,http://readeros.duckdns.org',
+    )
     return [origin.strip() for origin in raw.split(',') if origin.strip()]
 
 


### PR DESCRIPTION
### Motivation
- Allow requests from the new DuckDNS hostname to pass CORS checks by default so the frontend served at that domain can interact with the backend without requiring extra environment configuration.

### Description
- Update the `CORS_ORIGINS` fallback in `backend/app/main.py` to include `https://readeros.duckdns.org` and `http://readeros.duckdns.org` alongside the existing `localhost` defaults by changing the `_parse_cors_origins` default string.
- Preserve the existing `allow_origin_regex`, methods, and headers configuration so development defaults and IPv4 localhost allowances remain unchanged.

### Testing
- Ran `python -m py_compile backend/app/main.py` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df896ad41c833192d6e6a8f3508920)