### PR TITLE
Allow DuckDNS host in Vite dev server and ignore frontend build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 data/
+
+frontend/node_modules/
+frontend/dist/

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    allowedHosts: ['readeros.duckdns.org'],
+  },
+});


### PR DESCRIPTION
### Motivation
- Fix host-header blocking when accessing the frontend via the domain and port and prevent accidental tracking of local frontend build artifacts.

### Description
- Add `frontend/vite.config.js` with `server.allowedHosts: ['readeros.duckdns.org']` to permit the DuckDNS hostname in the Vite dev server.
- Update `.gitignore` to ignore `frontend/node_modules/` and `frontend/dist/` so local frontend artifacts are not committed.

### Testing
- Ran `npm run build` in `frontend/` and the Vite build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8ae24a94833193b87334ba7c4dd8)