### PR TITLE
Make mark-read delete article and purge related resources

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -615,9 +615,26 @@ def mark_read_state(article_id: int, payload: MarkReadPayload, db: Session = Dep
     article = db.get(Article, article_id)
     if not article:
         raise HTTPException(404)
+    if payload.is_read:
+        video_item_id = article.video_item_id
+        db.query(CollectionArticle).filter(CollectionArticle.article_id == article_id).delete(synchronize_session=False)
+        db.query(ReadingProgress).filter(ReadingProgress.article_id == article_id).delete(synchronize_session=False)
+        db.query(ArticleVersion).filter(ArticleVersion.article_id == article_id).delete(synchronize_session=False)
+        db.query(Article).filter(Article.id == article_id).delete(synchronize_session=False)
+        # Keep the VideoItem row so future refreshes deduplicate by source+video_id and do not fetch again.
+        db.query(Transcript).filter(Transcript.video_item_id == video_item_id).delete(synchronize_session=False)
+        db.query(ItemStatusTransition).filter(ItemStatusTransition.video_item_id == video_item_id).delete(synchronize_session=False)
+        db.query(JobItem).filter(JobItem.video_item_id == video_item_id).delete(synchronize_session=False)
+        db.query(Job).filter(Job.video_item_id == video_item_id).delete(synchronize_session=False)
+        video_item = db.get(VideoItem, video_item_id)
+        if video_item:
+            video_item.status = ItemStatus.skipped_by_policy
+            video_item.status_message = "Marked read and removed by user"
+        db.commit()
+        return {"saved": True, "deleted": True}
     article.is_read = payload.is_read
     db.commit()
-    return {"saved": True}
+    return {"saved": True, "deleted": False}
 
 
 @router.post('/articles/{article_id}/progress')

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -320,8 +320,24 @@ function Library() {
 
   const markRead = useMutation({
     mutationFn: async ({ articleId, isRead }: { articleId: number; isRead: boolean }) => api.post(`/articles/${articleId}/read-state`, { is_read: isRead }),
-    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ['library'] }); notify('Read state updated.'); },
-    onError: () => notify('Could not update read state.', 'error'),
+    onMutate: async ({ articleId, isRead }) => {
+      if (!isRead) return;
+      await queryClient.cancelQueries({ queryKey: ['library'] });
+      const snapshots = queryClient.getQueriesData<LibraryItem[]>({ queryKey: ['library'] });
+      snapshots.forEach(([key, current]) => {
+        if (!current) return;
+        queryClient.setQueryData(key, current.filter((item) => item.article_id !== articleId));
+      });
+      return { snapshots };
+    },
+    onSuccess: (_result, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['library'] });
+      notify(variables.isRead ? 'Article removed.' : 'Read state updated.');
+    },
+    onError: (_error, variables, context) => {
+      context?.snapshots?.forEach(([key, value]: [readonly unknown[], LibraryItem[] | undefined]) => queryClient.setQueryData(key, value));
+      notify(variables.isRead ? 'Could not remove article.' : 'Could not update read state.', 'error');
+    },
   });
   const addToCollection = useMutation({
     mutationFn: async ({ articleId, collectionId }: { articleId: number; collectionId: number }) => api.post(`/collections/${collectionId}/articles/${articleId}`),
@@ -404,6 +420,7 @@ function Library() {
 
 function Reader() {
   const { id } = useParams();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [selectedVersion, setSelectedVersion] = useState<number | null>(null);
   const [tab, setTab] = useState<'article' | 'transcript'>('article');
@@ -422,7 +439,16 @@ function Reader() {
   });
   const markRead = useMutation({
     mutationFn: async (isRead: boolean) => api.post(`/articles/${id}/read-state`, { is_read: isRead }),
-    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ['article', id] }); notify('Read state updated.'); },
+    onSuccess: (_result, isRead) => {
+      queryClient.invalidateQueries({ queryKey: ['article', id] });
+      queryClient.invalidateQueries({ queryKey: ['library'] });
+      if (isRead) {
+        notify('Article removed.');
+        navigate('/library');
+        return;
+      }
+      notify('Read state updated.');
+    },
     onError: () => notify('Could not update read state.', 'error'),
   });
   const saveProgress = useMutation({ mutationFn: async (payload: { position: number; total: number }) => api.post(`/articles/${id}/progress`, payload) });


### PR DESCRIPTION
### Motivation
- Allow users to have a true "delete on mark read" workflow where marking an article read removes it immediately and prevents the system from fetching/processing it again.
- Ensure associated resources (versions, progress, collections, transcripts, processing jobs) are cleaned up when users remove an article to reclaim space and avoid reprocessing.
- Provide immediate UX feedback by removing the article card instantly in the library and returning the reader to the library after removal.

### Description
- Backend: changed `POST /articles/{article_id}/read-state` to, when `is_read=true`, delete `CollectionArticle`, `ReadingProgress`, `ArticleVersion`, and the `Article` row and to purge related `Transcript`, `ItemStatusTransition`, `JobItem`, and `Job` rows for the associated `video_item_id`, then mark the `VideoItem` as `skipped_by_policy` with a `status_message` to prevent future refetch/processing, returning `{"saved": True, "deleted": True}`; when not deleting, returns `{"saved": True, "deleted": False}` (file `backend/app/api/routes.py`).
- Frontend (Library): added optimistic removal in the `markRead` mutation that cancels/updates cached `['library']` queries to remove the card immediately, snapshots caches for rollback on error, and updates success/error notifications (file `frontend/src/main.tsx`).
- Frontend (Reader): updated `markRead` in the Reader to invalidate `['article', id]` and `['library']`, navigate back to `/library` when the article was removed, and show the appropriate notifications (file `frontend/src/main.tsx`).

### Testing
- Compiled backend Python files with `python -m compileall backend/app` which completed successfully.
- Built frontend with `npm --prefix frontend run build` which completed successfully.
- No additional automated unit tests were added or run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e025b58c5c8331b8653bcbd0035053)