### PR TITLE
Fix infinite reader progress POST loop when article is missing

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useEffect, useMemo, useState } from 'react';
+import React, { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import {
   BrowserRouter,
@@ -451,7 +451,11 @@ function Reader() {
     },
     onError: () => notify('Could not update read state.', 'error'),
   });
-  const saveProgress = useMutation({ mutationFn: async (payload: { position: number; total: number }) => api.post(`/articles/${id}/progress`, payload) });
+  const saveProgress = useMutation({
+    mutationFn: async (payload: { position: number; total: number }) => api.post(`/articles/${id}/progress`, payload),
+    retry: false,
+  });
+  const lastProgressSaveKey = useRef<string | null>(null);
 
   const version = useMemo(() => {
     const versions = detail.data?.versions ?? [];
@@ -478,9 +482,12 @@ function Reader() {
   const activeContent = tab === 'article' ? (body || 'No content available.') : (transcript.data?.text || 'Transcript unavailable.');
 
   useEffect(() => {
-    if (!id || !activeContent.trim()) return;
+    if (!id || !detail.isSuccess || !detail.data?.id || !activeContent.trim()) return;
+    const progressKey = `${id}:${tab}:${version?.version ?? 'none'}:${activeContent.length}`;
+    if (lastProgressSaveKey.current === progressKey) return;
+    lastProgressSaveKey.current = progressKey;
     saveProgress.mutate({ position: 1, total: 1 });
-  }, [activeContent, id, saveProgress, tab, version?.version]);
+  }, [activeContent, detail.data?.id, detail.isSuccess, id, tab, version?.version]);
 
   return (
     <Page title='Reader'>


### PR DESCRIPTION
### Motivation
- Prevent the frontend from repeatedly POSTing reading progress for an article that was deleted or missing, which produced continuous `POST /api/articles/:id/progress 404` log spam on the backend.
- Avoid saving progress while the article detail hasn't successfully loaded to reduce spurious writes after deletion or network errors.
- Reduce repeated identical progress writes caused by rerenders.

### Description
- Updated `frontend/src/main.tsx` to import `useRef` and add a `lastProgressSaveKey` `useRef` to deduplicate progress saves based on `id`, `tab`, `version`, and `activeContent.length`.
- Configured the `saveProgress` mutation created with `useMutation` to disable automatic retries by setting `retry: false` so a `404` response will not cause repeated background attempts.
- Gated the progress write in the `useEffect` to require `detail.isSuccess` and `detail.data?.id` before calling the mutation, and adjusted the effect dependencies accordingly.

### Testing
- Ran `npm run build` in `frontend/` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e116173c188331a789a619802ed864)