### PR TITLE
Fix iPhone black screen by hardening mobile startup and render paths

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,1 +1,12 @@
-<!doctype html><html><body><div id='root'></div><script type='module' src='/src/main.tsx'></script></body></html>
+<!doctype html>
+<html lang='en'>
+  <head>
+    <meta charset='UTF-8' />
+    <meta name='viewport' content='width=device-width, initial-scale=1, viewport-fit=cover' />
+    <title>ReimagineDoomscrolling</title>
+  </head>
+  <body>
+    <div id='root'></div>
+    <script type='module' src='/src/main.tsx'></script>
+  </body>
+</html>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -98,6 +98,10 @@ type Notification = {
   message: string;
 };
 
+function slugifyAnchor(value: string) {
+  return value.trim().toLowerCase().replace(/\s+/g, '-');
+}
+
 const NotificationContext = React.createContext<{ notify: (message: string, kind?: Notification['kind']) => void }>({
   notify: () => undefined,
 });
@@ -133,7 +137,7 @@ function Home() {
 
   const activeSources = (sources.data ?? []).filter((s) => s.state === 'enabled').length;
   const unreadCount = (library.data ?? []).filter((a) => !a.is_read).length;
-  const continueReading = (library.data ?? []).find((a) => (a.reading_progress.total || 0) > 0 && (a.reading_progress.position || 0) > 0 && !a.is_read);
+  const continueReading = (library.data ?? []).find((a) => ((a.reading_progress?.total ?? 0) > 0) && ((a.reading_progress?.position ?? 0) > 0) && !a.is_read);
 
   return (
     <Page title='Dashboard'>
@@ -744,12 +748,12 @@ function Settings() {
       <article className='card settings-section-index'>
         <p className='muted'>Sections</p>
         <div className='row'>
-          {groups.map((group) => <a key={group.title} href={`#settings-${group.title.replaceAll(' ', '-').toLowerCase()}`}>{group.title}</a>)}
+          {groups.map((group) => <a key={group.title} href={`#settings-${slugifyAnchor(group.title)}`}>{group.title}</a>)}
         </div>
       </article>
       <div className='settings-grid settings-grid-wide'>
         {groups.map((group) => (
-          <article className='card settings-group' key={group.title} id={`settings-${group.title.replaceAll(' ', '-').toLowerCase()}`}>
+          <article className='card settings-group' key={group.title} id={`settings-${slugifyAnchor(group.title)}`}>
             <header>
               <h3>{group.title}</h3>
               <p className='muted'>{group.description}</p>
@@ -832,7 +836,7 @@ function Diagnostics() {
       <div className='settings-grid'>
         {Object.entries(diag.data ?? {}).map(([k, v]) => (
           <article className='card diag-card' key={k}>
-            <p className='label'>{k.replaceAll('_', ' ')}</p>
+            <p className='label'>{k.replace(/_/g, ' ')}</p>
             {renderValue(v)}
           </article>
         ))}


### PR DESCRIPTION
### Motivation
- Mobile Safari (notably on iPhone) could render a pure black screen due to missing document metadata and runtime failures from unsupported string APIs or unexpected backend payload shapes.
- The settings/index anchors used `replaceAll` and diagnostics labels used `replaceAll`, which can throw on older engines and abort rendering.
- Dashboard code assumed `reading_progress` was always present which can cause render-time crashes when backend responses omit that field.

### Description
- Add a proper HTML document head in `frontend/index.html` with `charset`, `viewport` (`width=device-width, initial-scale=1, viewport-fit=cover`), and `title` to ensure correct mobile layout initialization.
- Introduce a `slugifyAnchor` helper in `frontend/src/main.tsx` and replace `replaceAll(' ', '-')` / `replaceAll('_', ' ')` usages with compatibility-safe implementations using regex to avoid relying on `String.prototype.replaceAll`.
- Harden the dashboard `continueReading` calculation by using optional chaining and null-coalescing (`a.reading_progress?.total ?? 0`) to tolerate missing `reading_progress` values.

### Testing
- Ran the frontend production build with `npm --prefix frontend run build`, and the build completed successfully (Vite produced `dist/` assets).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2fbae2ec083319c2959313558fae5)