### PR TITLE
Always use local Whisper transcription; remove YouTube transcript path

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -38,7 +38,6 @@ from app.services.diagnostics import (
     check_lmstudio_connectivity,
     check_openai_connectivity,
     check_storage_writable,
-    check_transcript_dependency,
 )
 from app.services.generation import ProviderConfig, generate_article, render_prompt
 from app.services.ops import redact_secrets
@@ -98,8 +97,6 @@ DEFAULT_APP_SETTINGS = {
     "source_default_skip_shorts": "true",
     "source_default_min_duration_seconds": "180",
     "source_default_dedup_policy": "source_video_id",
-    "transcript_first": "true",
-    "transcript_fallback_enabled": "true",
     "whisper_model_size": "base",
     "transcription_cpu_threads": "4",
     "transcription_language_hint": "",
@@ -141,8 +138,6 @@ def settings_schema():
         ],
         "transcript": [
             "transcript_languages",
-            "transcript_first",
-            "transcript_fallback_enabled",
             "whisper_model_size",
             "transcription_cpu_threads",
             "transcription_language_hint",
@@ -753,7 +748,6 @@ def diagnostics(db: Session = Depends(get_db)):
         'storage': check_storage_writable("./tmp"),
         'ffmpeg': ffmpeg_status,
         'yt_dlp': yt_dlp_status,
-        'transcript_dependency': check_transcript_dependency(),
         'faster_whisper': check_faster_whisper(),
         'openai_connectivity': check_openai_connectivity(openai_base_url, openai_api_key),
         'lmstudio_connectivity': check_lmstudio_connectivity(lmstudio_base_url),

--- a/backend/app/services/diagnostics.py
+++ b/backend/app/services/diagnostics.py
@@ -41,14 +41,6 @@ def check_binary(command: str, fallback: str = "") -> dict:
     return {"ok": bool(resolved), "command": command, "path": resolved or "", "version": output}
 
 
-def check_transcript_dependency() -> dict:
-    try:
-        importlib.import_module("youtube_transcript_api")
-        return {"ok": True, "version": _pkg_version("youtube-transcript-api")}
-    except Exception as exc:
-        return {"ok": False, "error": str(exc)}
-
-
 def check_faster_whisper() -> dict:
     try:
         mod = importlib.import_module("faster_whisper")

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -19,7 +19,7 @@ from app.models.entities import (
 )
 from app.services.generation import ProviderConfig, generate_article, generate_text, render_prompt
 from app.services.ops import log_event
-from app.services.transcript import fetch_transcript, should_fallback_to_transcription, transcribe_audio_locally
+from app.services.transcript import transcribe_audio_locally
 from app.services.youtube import discover_videos, evaluate_video_policy, normalize_source_url, resolve_source_identity
 
 
@@ -252,37 +252,27 @@ def process_video_item(db, item_id: int):
         language_pref = _get_setting(db, "transcript_languages", "en")
         languages = [lang.strip() for lang in language_pref.split(",") if lang.strip()] or ["en"]
 
-        strategy = source.transcript_strategy if source else "transcript_first"
-        fallback_enabled = source.fallback_enabled if source else True
+        strategy = "force_local_transcription"
         text = ""
-        source_kind = "youtube_transcript"
-        fallback_used = False
+        source_kind = "local_transcription"
+        fallback_used = True
         transcribe_meta = {"transcription_seconds": 0, "audio_retained_path": ""}
 
-        if strategy != "force_local_transcription":
-            try:
-                text, source_kind = fetch_transcript(item.url, languages, strategy=strategy)
-            except Exception:
-                text = ""
-
-        if not text and should_fallback_to_transcription(strategy, False, fallback_enabled):
-            _set_item_status(db, item, ItemStatus.audio_downloaded)
-            _set_item_status(db, item, ItemStatus.transcription_started)
-            yt_dlp_command = _get_setting(db, "yt_dlp_path", "yt-dlp").strip() or "yt-dlp"
-            ffmpeg_command = _get_setting(db, "ffmpeg_path", "ffmpeg").strip() or "ffmpeg"
-            retain_failed = _get_setting(db, "retain_failed_audio", "false").lower() in {"1", "true", "yes", "on"}
-            delete_audio_after_success = _get_setting(db, "delete_audio_after_success", "true").lower() in {"1", "true", "yes", "on"}
-            text, transcribe_meta = transcribe_audio_locally(
-                item.url,
-                yt_dlp_command=yt_dlp_command,
-                ffmpeg_command=ffmpeg_command,
-                retain_audio_on_failure=retain_failed,
-                delete_audio_after_success=delete_audio_after_success,
-            )
-            source_kind = "local_transcription"
-            fallback_used = True
-            _set_item_status(db, item, ItemStatus.transcription_completed)
-        elif text:
+        _set_item_status(db, item, ItemStatus.audio_downloaded)
+        _set_item_status(db, item, ItemStatus.transcription_started)
+        yt_dlp_command = _get_setting(db, "yt_dlp_path", "yt-dlp").strip() or "yt-dlp"
+        ffmpeg_command = _get_setting(db, "ffmpeg_path", "ffmpeg").strip() or "ffmpeg"
+        retain_failed = _get_setting(db, "retain_failed_audio", "false").lower() in {"1", "true", "yes", "on"}
+        delete_audio_after_success = _get_setting(db, "delete_audio_after_success", "true").lower() in {"1", "true", "yes", "on"}
+        text, transcribe_meta = transcribe_audio_locally(
+            item.url,
+            yt_dlp_command=yt_dlp_command,
+            ffmpeg_command=ffmpeg_command,
+            retain_audio_on_failure=retain_failed,
+            delete_audio_after_success=delete_audio_after_success,
+        )
+        _set_item_status(db, item, ItemStatus.transcription_completed)
+        if text:
             _set_item_status(db, item, ItemStatus.transcript_found)
         else:
             _set_item_status(db, item, ItemStatus.transcript_unavailable)

--- a/backend/app/services/transcript.py
+++ b/backend/app/services/transcript.py
@@ -7,7 +7,6 @@ import time
 from urllib.parse import parse_qs, urlparse
 
 from faster_whisper import WhisperModel
-from youtube_transcript_api import YouTubeTranscriptApi
 
 
 def select_transcript_strategy(source) -> str:
@@ -34,27 +33,6 @@ def _extract_video_id(video_url: str) -> str:
     if len(parts) >= 2 and parts[0] in {"embed", "shorts"}:
         return parts[1]
     raise ValueError("Unable to parse YouTube video id from URL")
-
-
-def fetch_transcript(video_url: str, languages: list[str], strategy: str = "transcript_first") -> tuple[str, str]:
-    video_id = _extract_video_id(video_url)
-    language_order = languages or ["en"]
-
-    normalized = (strategy or "").lower()
-    fetched = YouTubeTranscriptApi().list(video_id)
-    transcript_obj = None
-    if normalized in {"manual_only", "prefer_manual_then_auto"}:
-        transcript_obj = fetched.find_manually_created_transcript(language_order)
-    elif normalized == "auto_only":
-        transcript_obj = fetched.find_generated_transcript(language_order)
-    else:
-        transcript_obj = fetched.find_transcript(language_order)
-
-    snippets = transcript_obj.fetch()
-    text = "\n".join(part.text.strip() for part in snippets if part.text.strip())
-    if not text:
-        return "", "youtube_transcript"
-    return text, "youtube_transcript"
 
 
 def transcribe_audio_locally(

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -3,7 +3,29 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
-def test_settings_source_refresh_completes_without_placeholder_failures():
+def test_settings_source_refresh_completes_without_placeholder_failures(monkeypatch):
+    from app.services import pipeline
+
+    monkeypatch.setattr(
+        pipeline,
+        "discover_videos",
+        lambda _source: [
+            {
+                "video_id": "abc123",
+                "url": "https://www.youtube.com/watch?v=abc123",
+                "title": "ABC",
+                "duration": 600,
+                "is_live": False,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "transcribe_audio_locally",
+        lambda *_args, **_kwargs: ("local transcript", {"transcription_seconds": 1, "audio_retained_path": ""}),
+    )
+    monkeypatch.setattr(pipeline, "generate_article", lambda *_args, **_kwargs: "Generated body")
+
     with TestClient(app) as client:
         r = client.put('/api/settings', json={'provider': 'openai'})
         assert r.status_code == 200

--- a/backend/tests/test_integration_additional.py
+++ b/backend/tests/test_integration_additional.py
@@ -42,7 +42,11 @@ def test_source_refresh_deduplicates_and_records_status_timeline(monkeypatch):
 
     monkeypatch.setattr(pipeline, 'discover_videos', fake_discover)
     monkeypatch.setattr(pipeline, 'resolve_source_identity', lambda _url: {'normalized_url': 'https://www.youtube.com/channel/xyz', 'canonical_url': 'https://www.youtube.com/channel/xyz', 'channel_id': 'xyz', 'title': 'XYZ'})
-    monkeypatch.setattr(pipeline, 'fetch_transcript', lambda *_args, **_kwargs: ('hello world', 'youtube_transcript'))
+    monkeypatch.setattr(
+        pipeline,
+        'transcribe_audio_locally',
+        lambda *_args, **_kwargs: ('hello world', {'transcription_seconds': 1, 'audio_retained_path': ''}),
+    )
     monkeypatch.setattr(pipeline, 'generate_article', lambda *_args, **_kwargs: 'Generated body')
 
     with TestClient(app) as client:
@@ -55,9 +59,10 @@ def test_source_refresh_deduplicates_and_records_status_timeline(monkeypatch):
 
         lib = client.get('/api/library')
         assert lib.status_code == 200
-        assert len(lib.json()) == 1
+        source_rows = [row for row in lib.json() if row['source_id'] == sid]
+        assert len(source_rows) == 1
 
-        item_id = lib.json()[0]['video_item_id']
+        item_id = source_rows[0]['video_item_id']
         timeline = client.get(f'/api/items/{item_id}/timeline')
         assert timeline.status_code == 200
         assert len(timeline.json()) >= 3

--- a/backend/tests/test_integration_testing_matrix.py
+++ b/backend/tests/test_integration_testing_matrix.py
@@ -52,7 +52,11 @@ def test_integration_real_life_lore_refresh_discovery_and_generation(monkeypatch
             },
         ],
     )
-    monkeypatch.setattr(pipeline, "fetch_transcript", lambda *_args, **_kwargs: ("Transcript text", "youtube_transcript"))
+    monkeypatch.setattr(
+        pipeline,
+        "transcribe_audio_locally",
+        lambda *_args, **_kwargs: ("Transcript text", {"transcription_seconds": 1, "audio_retained_path": ""}),
+    )
     monkeypatch.setattr(pipeline, "generate_article", lambda *_args, **_kwargs: "Generated article body")
 
     with TestClient(app) as client:
@@ -68,7 +72,7 @@ def test_integration_real_life_lore_refresh_discovery_and_generation(monkeypatch
         item_id = library.json()[0]["video_item_id"]
         transcript = client.get(f"/api/transcripts/{item_id}")
         assert transcript.status_code == 200
-        assert transcript.json()["source"] == "youtube_transcript"
+        assert transcript.json()["source"] == "local_transcription"
 
         timeline = client.get(f"/api/items/{item_id}/timeline")
         assert timeline.status_code == 200
@@ -107,9 +111,6 @@ def test_integration_transcript_fallback_retry_and_regeneration(monkeypatch):
 
     calls = {"transcribe": 0, "generate": 0}
 
-    def fake_fetch(*_args, **_kwargs):
-        raise RuntimeError("transcript unavailable")
-
     def fake_transcribe(*_args, **kwargs):
         calls["transcribe"] += 1
         assert kwargs.get("delete_audio_after_success") is True
@@ -121,7 +122,6 @@ def test_integration_transcript_fallback_retry_and_regeneration(monkeypatch):
         calls["generate"] += 1
         return f"Generated v{calls['generate']}"
 
-    monkeypatch.setattr(pipeline, "fetch_transcript", fake_fetch)
     monkeypatch.setattr(pipeline, "transcribe_audio_locally", fake_transcribe)
     monkeypatch.setattr(pipeline, "generate_article", fake_generate)
 
@@ -195,7 +195,11 @@ def test_failure_paths_invalid_source_and_generation_provider_errors(monkeypatch
                 }
             ],
         )
-        monkeypatch.setattr(pipeline, "fetch_transcript", lambda *_args, **_kwargs: ("text", "youtube_transcript"))
+        monkeypatch.setattr(
+            pipeline,
+            "transcribe_audio_locally",
+            lambda *_args, **_kwargs: ("text", {"transcription_seconds": 1, "audio_retained_path": ""}),
+        )
         monkeypatch.setattr(pipeline, "generate_article", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("openai auth failure")))
 
         source_id = _create_source(client, "/provider-openai")

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -585,7 +585,7 @@ function Settings() {
   const settingsTemplate = useMemo(() => ({
     timezone: 'UTC',
     source_default_discovery_mode: 'latest_n', source_default_max_videos: '10', source_default_rolling_window_hours: '72', source_default_skip_shorts: 'true', source_default_min_duration_seconds: '180', source_default_dedup_policy: 'source_video_id',
-    transcript_languages: 'en', transcript_first: 'true', transcript_fallback_enabled: 'true', whisper_model_size: 'base', transcription_cpu_threads: '4', transcription_language_hint: '',
+    transcript_languages: 'en', whisper_model_size: 'base', transcription_cpu_threads: '4', transcription_language_hint: '',
     generation_provider: 'openai', generation_model: 'gpt-4.1-mini', generation_temperature: '0.2', generation_timeout_seconds: '300', generation_max_tokens: '30000', global_prompt_template: 'Convert the transcript into a polished article.\n\n{{transcript}}', openai_api_key: '', openai_base_url: 'https://api.openai.com/v1', lmstudio_base_url: 'http://localhost:1234/v1',
     title_output_language: 'English',
     reader_font_family: 'sans', reader_font_size: '17', reader_line_width: '72',
@@ -630,12 +630,10 @@ function Settings() {
       ],
     },
     {
-      title: 'Transcript',
-      description: 'Language strategy and transcription engine behavior.',
+      title: 'Transcription',
+      description: 'Everything is processed locally with Whisper.',
       fields: [
         { key: 'transcript_languages', label: 'Language priority', type: 'text', description: 'Comma-separated language codes, e.g. en,es.' },
-        { key: 'transcript_first', label: 'Try transcript before ASR', type: 'select', options: [{ label: 'Enabled', value: 'true' }, { label: 'Disabled', value: 'false' }] },
-        { key: 'transcript_fallback_enabled', label: 'Allow fallback', type: 'select', options: [{ label: 'Enabled', value: 'true' }, { label: 'Disabled', value: 'false' }] },
         { key: 'whisper_model_size', label: 'Whisper model', type: 'select', options: [{ label: 'Tiny', value: 'tiny' }, { label: 'Base', value: 'base' }, { label: 'Small', value: 'small' }, { label: 'Medium', value: 'medium' }, { label: 'Large', value: 'large' }] },
         { key: 'transcription_cpu_threads', label: 'CPU threads', type: 'range', min: 1, max: 32, step: 1 },
         { key: 'transcription_language_hint', label: 'Language hint', type: 'text' },

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ celery==5.4.0
 redis==5.2.1
 alembic==1.14.1
 yt-dlp==2025.3.31
-youtube-transcript-api==1.1.0
 faster-whisper==1.1.1


### PR DESCRIPTION
### Motivation
- YouTube transcripts are unreliable, so the pipeline should always fall back to a deterministic local ASR path using Whisper for transcription.

### Description
- Force the processing pipeline to run local transcription by calling `transcribe_audio_locally` for every video and mark transcripts as `local_transcription` in `backend/app/services/pipeline.py`.
- Removed the `fetch_transcript` path and `youtube-transcript-api` usage from `backend/app/services/transcript.py` and dropped `youtube-transcript-api` from `requirements.txt` so all transcription is local via Whisper/`yt-dlp`/`ffmpeg`.
- Cleaned up diagnostics and settings: removed transcript-download related checks and removed `transcript_first`/`transcript_fallback_enabled` settings from `backend/app/api/routes.py` and `backend/app/services/diagnostics.py`.
- Updated the frontend settings copy and fields in `frontend/src/main.tsx` to reflect local-only transcription and updated integration tests to mock `transcribe_audio_locally` and assert `local_transcription` behavior.

### Testing
- Ran `pytest backend/tests -q` and observed all backend tests passing (`32 passed`).
- Built the frontend with `npm --prefix frontend run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7430bbc14833196dabe401af84211)