### PR TITLE
Improve mobile navigation and responsive layout

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import {
   NavLink,
   Route,
   Routes,
+  useLocation,
   useNavigate,
   useParams,
   useSearchParams,
@@ -849,7 +850,9 @@ function Logs() {
 }
 
 function Layout() {
+  const location = useLocation();
   const [navCollapsed, setNavCollapsed] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const notify = (message: string, kind: Notification['kind'] = 'success') => {
     const id = Date.now() + Math.floor(Math.random() * 1000);
@@ -859,6 +862,12 @@ function Layout() {
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', 'dark');
   }, []);
+  useEffect(() => {
+    setMobileMenuOpen(false);
+  }, [location.pathname]);
+  useEffect(() => {
+    if (mobileMenuOpen) setNavCollapsed(false);
+  }, [mobileMenuOpen]);
 
   const links = [
     ['/', 'Home', '🏠'],
@@ -872,7 +881,16 @@ function Layout() {
   ] as const;
   return (
     <NotificationContext.Provider value={{ notify }}>
-      <div className={`layout ${navCollapsed ? 'nav-collapsed' : ''}`}>
+      <div className={`layout ${navCollapsed ? 'nav-collapsed' : ''} ${mobileMenuOpen ? 'mobile-menu-open' : ''}`}>
+        <button
+          type='button'
+          className='mobile-nav-toggle'
+          aria-label={mobileMenuOpen ? 'Close navigation menu' : 'Open navigation menu'}
+          aria-expanded={mobileMenuOpen}
+          onClick={() => setMobileMenuOpen((v) => !v)}
+        >
+          {mobileMenuOpen ? '✕' : '☰'}
+        </button>
         <aside>
         <div className='sidebar-shell'>
           <div className='sidebar-top'>
@@ -895,6 +913,7 @@ function Layout() {
           {!navCollapsed ? <div className='sidebar-footer muted'>Monochrome UI locked</div> : null}
         </div>
         </aside>
+        {mobileMenuOpen ? <button type='button' className='mobile-backdrop' aria-label='Close menu' onClick={() => setMobileMenuOpen(false)} /> : null}
         <main>
           <Routes>
             <Route path='/' element={<Home />} />

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -112,6 +112,12 @@ main { padding: 2rem; }
 .page { display: grid; gap: 1rem; }
 .page-header h1 { margin: 0; font-size: clamp(1.6rem, 2.5vw, 2rem); }
 .page-header p { margin: .35rem 0 0; }
+.mobile-nav-toggle {
+  display: none;
+}
+.mobile-backdrop {
+  display: none;
+}
 
 .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 1rem; }
 .stack { display: grid; gap: .85rem; padding-left: 1rem; }
@@ -376,19 +382,87 @@ textarea {
 @media (max-width: 1024px) {
   .layout { grid-template-columns: 1fr; }
   .layout.nav-collapsed { grid-template-columns: 1fr; }
+  .mobile-nav-toggle {
+    display: inline-flex;
+    position: fixed;
+    top: .8rem;
+    right: .8rem;
+    z-index: 1200;
+    width: 2.5rem;
+    height: 2.5rem;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    background: #111;
+  }
   aside {
-    position: static;
-    height: auto;
-    border-right: none;
-    border-bottom: 1px solid rgba(136, 164, 237, 0.2);
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: min(82vw, 320px);
+    max-width: 100%;
+    height: 100vh;
+    z-index: 1150;
+    transform: translateX(-100%);
+    transition: transform .2s ease;
+    border-right: 1px solid var(--border);
+    border-bottom: none;
+    overflow: auto;
+  }
+  .layout.mobile-menu-open aside {
+    transform: translateX(0);
+  }
+  .mobile-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 1100;
+    background: rgba(0, 0, 0, .55);
+    border: 0;
+    padding: 0;
+  }
+  .layout.mobile-menu-open main {
+    pointer-events: none;
+    user-select: none;
+  }
+  .layout.nav-collapsed .sidebar-top {
+    grid-template-columns: minmax(0, 1fr) auto;
+    justify-items: stretch;
+  }
+  .layout.nav-collapsed aside nav a {
+    justify-content: flex-start;
+    padding: .74rem .86rem;
+  }
+  .layout.nav-collapsed .sidebar-footer {
+    display: block;
+  }
+  .layout.nav-collapsed .sidebar-brand {
+    display: block;
+  }
+  .layout.nav-collapsed aside nav a span:last-child {
+    display: inline;
+  }
+  aside {
+    padding-top: 1.2rem;
   }
   .library-shell { grid-template-columns: 1fr; }
   .library-toolbar { grid-template-columns: 1fr; }
   .channel-filter { position: static; }
-  main { padding: 1rem; }
+  main { padding: 4rem .9rem 1rem; }
   .notification-stack {
     left: 1rem;
     right: 1rem;
     width: auto;
+  }
+  .hero {
+    flex-direction: column;
+  }
+  .row > * {
+    width: 100%;
+  }
+  table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a usable mobile GUI by converting the sidebar into a mobile-friendly slide-in drawer with an accessible toggle and backdrop.
- Prevent desktop collapsed-sidebar state from leaking into mobile and improve small-screen layout ergonomics for forms, hero content, and tables.

### Description
- Added mobile navigation state and routing integration in `frontend/src/main.tsx` by introducing `useLocation`, `mobileMenuOpen`, a hamburger toggle button, dismissible backdrop, auto-close on route change, and a guard to reset `navCollapsed` when opening the mobile menu.
- Added semantic accessibility attributes (`aria-label`, `aria-expanded`) to the mobile toggle and backdrop controls.
- Extended `frontend/src/styles.css` with `.mobile-nav-toggle`, `.mobile-backdrop` and off-canvas `aside` rules under `@media (max-width: 1024px)` so the sidebar slides in and the page is disabled while open.
- Improved mobile layout spacing and stacking by increasing top `main` padding, stacking `.hero` and `.row` children, and enabling horizontal table scrolling for narrow viewports.

### Testing
- Ran a production build with `npm --prefix frontend run build` which completed successfully.
- Attempted an automated mobile screenshot with Playwright (`npx playwright screenshot --device='iPhone 12'`) but the run could not complete due to missing browser host libraries in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f04aff914c8331be4e9ca2aef1ff19)