### PR TITLE
Mobile-first Library UI overhaul with corrected filter and card layout

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -115,6 +115,21 @@ function useNotifications() {
   return React.useContext(NotificationContext);
 }
 
+function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState(() => (typeof window !== 'undefined' ? window.matchMedia(query).matches : false));
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const mediaQuery = window.matchMedia(query);
+    const update = () => setMatches(mediaQuery.matches);
+    update();
+    mediaQuery.addEventListener('change', update);
+    return () => mediaQuery.removeEventListener('change', update);
+  }, [query]);
+
+  return matches;
+}
+
 function getApiErrorMessage(error: unknown, fallback: string) {
   const detail = (error as AxiosError<{ detail?: unknown }>)?.response?.data?.detail;
   if (typeof detail !== 'string') return fallback;
@@ -310,6 +325,7 @@ function Library() {
   const [params, setParams] = useSearchParams();
   const queryClient = useQueryClient();
   const { notify } = useNotifications();
+  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
   const q = params.get('q') ?? '';
   const source = params.get('source') ?? '';
   const selectedChannel = params.get('channel') ?? 'all';
@@ -317,6 +333,7 @@ function Library() {
   const sort_by = params.get('sort_by') ?? 'import_time';
   const view = params.get('view') ?? 'grid';
   const collection_id = params.get('collection_id') ?? '';
+  const isMobileLibrary = useMediaQuery('(max-width: 1024px)');
 
   const collections = useQuery({ queryKey: ['collections'], queryFn: async () => (await api.get('/collections')).data as Collection[] });
   const library = useQuery({
@@ -329,6 +346,8 @@ function Library() {
     [entries],
   );
   const visibleEntries = selectedChannel === 'all' ? entries : entries.filter((item) => item.source_title === selectedChannel);
+  const unreadCount = entries.filter((item) => !item.is_read).length;
+  const readCount = Math.max(0, entries.length - unreadCount);
 
   const markRead = useMutation({
     mutationFn: async ({ articleId, isRead }: { articleId: number; isRead: boolean }) => api.post(`/articles/${articleId}/read-state`, { is_read: isRead }),
@@ -357,7 +376,17 @@ function Library() {
     onError: () => notify('Could not add to collection.', 'error'),
   });
 
-  const set = (k: string, v: string) => { const next = Object.fromEntries(params.entries()); if (v) next[k] = v; else delete next[k]; setParams(next); };
+  const set = (k: string, v: string) => {
+    const next = Object.fromEntries(params.entries());
+    if (v) next[k] = v;
+    else delete next[k];
+    setParams(next);
+  };
+
+  const resetFilters = () => {
+    setParams({});
+    setMobileFiltersOpen(false);
+  };
 
   const thumbnailFor = (item: LibraryItem) => {
     if (item.thumbnail_url) return item.thumbnail_url;
@@ -381,7 +410,7 @@ function Library() {
             <span className='badge'>Category: {item.video_category || 'Unrated'}</span>
             <span className='badge'>Score: {item.quality_score ?? 0}</span>
           </p>
-          <div className='row'>
+          <div className='row library-card-actions'>
             <Link to={`/reader/${item.article_id}`}>Open reader</Link>
             <button onClick={() => markRead.mutate({ articleId: item.article_id, isRead: !item.is_read })}>{item.is_read ? 'Mark unread' : 'Mark read'}</button>
             <select defaultValue='' onChange={(e) => e.target.value && addToCollection.mutate({ articleId: item.article_id, collectionId: Number(e.target.value) })}>
@@ -397,31 +426,68 @@ function Library() {
   return (
     <Page title='Library'>
       <section className='library-shell'>
-        <aside className='card channel-filter'>
-          <h3>Channels</h3>
-          <p className='muted channel-filter-label'>Filter by source</p>
-          {channels.map((channel) => (
-            <button
-              key={channel}
-              type='button'
-              className={`chip ${selectedChannel === channel ? 'active' : ''}`}
-              onClick={() => {
-                set('channel', channel);
-                set('source', channel === 'all' ? '' : channel);
-              }}
-            >
-              <span>{channel === 'all' ? 'All channels' : channel}</span>
-              <span className='muted'>{channel === 'all' ? entries.length : entries.filter((item) => item.source_title === channel).length}</span>
-            </button>
-          ))}
-        </aside>
+        {!isMobileLibrary ? (
+          <aside className='card channel-filter'>
+            <h3>Channels</h3>
+            <p className='muted channel-filter-label'>Filter by source</p>
+            {channels.map((channel) => (
+              <button
+                key={channel}
+                type='button'
+                className={`chip ${selectedChannel === channel ? 'active' : ''}`}
+                onClick={() => {
+                  set('channel', channel);
+                  set('source', channel === 'all' ? '' : channel);
+                }}
+              >
+                <span>{channel === 'all' ? 'All channels' : channel}</span>
+                <span className='muted'>{channel === 'all' ? entries.length : entries.filter((item) => item.source_title === channel).length}</span>
+              </button>
+            ))}
+          </aside>
+        ) : null}
         <div className='library-content'>
-          <article className='card library-toolbar'>
+          <article className='card library-mobile-summary'>
+            <div>
+              <p className='muted'>Showing {visibleEntries.length} of {entries.length}</p>
+              <h3>Unread {unreadCount} · Read {readCount}</h3>
+            </div>
+            <div className='library-view-toggle'>
+              <button type='button' className={view === 'grid' ? 'active' : ''} onClick={() => set('view', 'grid')}>Grid</button>
+              <button type='button' className={view === 'list' ? 'active' : ''} onClick={() => set('view', 'list')}>List</button>
+            </div>
+          </article>
+          <article className='card library-toolbar library-toolbar-search'>
             <input placeholder='Search videos, channels, or article text' defaultValue={q} onChange={(e) => set('q', e.target.value)} />
+            {isMobileLibrary ? (
+              <button type='button' onClick={() => setMobileFiltersOpen((current) => !current)}>
+                {mobileFiltersOpen ? 'Hide filters' : 'Show filters'}
+              </button>
+            ) : null}
+          </article>
+          <article className='card channel-filter-mobile'>
+            <p className='muted channel-filter-label'>Channel</p>
+            <div className='channel-chip-scroll'>
+              {channels.map((channel) => (
+                <button
+                  key={channel}
+                  type='button'
+                  className={`chip ${selectedChannel === channel ? 'active' : ''}`}
+                  onClick={() => {
+                    set('channel', channel);
+                    set('source', channel === 'all' ? '' : channel);
+                  }}
+                >
+                  <span>{channel === 'all' ? 'All' : channel}</span>
+                </button>
+              ))}
+            </div>
+          </article>
+          <article className={`card library-toolbar ${isMobileLibrary && !mobileFiltersOpen ? 'mobile-filter-hidden' : ''}`}>
             <select value={read_state} onChange={(e) => set('read_state', e.target.value)}><option value=''>All status</option><option value='unread'>Unread</option><option value='read'>Read</option></select>
             <select value={sort_by} onChange={(e) => set('sort_by', e.target.value)}><option value='import_time'>Newest imported</option><option value='publish_time'>Newest published</option><option value='source'>Channel A-Z</option><option value='title'>Title A-Z</option></select>
             <select value={collection_id} onChange={(e) => set('collection_id', e.target.value)}><option value=''>All collections</option>{(collections.data ?? []).map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}</select>
-            <select value={view} onChange={(e) => set('view', e.target.value)}><option value='grid'>Grid</option><option value='list'>List</option></select>
+            <button type='button' onClick={resetFilters}>Reset</button>
           </article>
           {cards(visibleEntries)}
         </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -168,6 +168,54 @@ main { padding: 2rem; }
 .library-shell { display: grid; grid-template-columns: 240px minmax(0, 1fr); gap: 1rem; align-items: flex-start; }
 .library-content { display: grid; gap: 1rem; }
 .library-toolbar { display: grid; gap: .7rem; grid-template-columns: minmax(220px, 1fr) repeat(4, minmax(130px, max-content)); }
+.library-toolbar-search {
+  grid-template-columns: minmax(220px, 1fr) auto;
+  align-items: center;
+}
+.library-mobile-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .8rem;
+}
+.library-mobile-summary h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+.library-mobile-summary .muted {
+  margin: 0 0 .25rem;
+}
+.library-view-toggle {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.library-view-toggle button {
+  border-radius: 0;
+  border: 0;
+  padding: .45rem .7rem;
+  min-width: 3.7rem;
+}
+.library-view-toggle button.active {
+  background: #fff;
+  color: #000;
+}
+.channel-filter-mobile {
+  display: none;
+}
+.channel-chip-scroll {
+  display: flex;
+  gap: .5rem;
+  overflow-x: auto;
+  padding-bottom: .25rem;
+}
+.channel-chip-scroll .chip {
+  white-space: nowrap;
+}
+.mobile-filter-hidden {
+  display: none;
+}
 .channel-filter {
   position: sticky;
   top: 1rem;
@@ -209,6 +257,9 @@ main { padding: 2rem; }
 }
 .library-cards article.card { padding: .95rem; }
 .library-cards.list article.card { max-width: 920px; }
+.library-card-actions > * {
+  flex: 1;
+}
 
 input, select, textarea, button {
   background: var(--surface-strong);
@@ -447,8 +498,19 @@ textarea {
   }
   .library-shell { grid-template-columns: 1fr; }
   .library-toolbar { grid-template-columns: 1fr; }
+  .library-toolbar-search { grid-template-columns: 1fr auto; }
+  .channel-filter-mobile { display: grid; gap: .45rem; }
+  .library-mobile-summary {
+    position: sticky;
+    top: 4rem;
+    z-index: 20;
+    background: #000;
+  }
+  .library-mobile-summary .library-view-toggle {
+    flex-shrink: 0;
+  }
   .channel-filter { position: static; }
-  main { padding: 4rem .9rem 1rem; }
+  main { padding: 4rem .75rem 1rem; }
   .notification-stack {
     left: 1rem;
     right: 1rem;
@@ -458,6 +520,9 @@ textarea {
     flex-direction: column;
   }
   .row > * {
+    width: 100%;
+  }
+  .library-card-actions > * {
     width: 100%;
   }
   table {


### PR DESCRIPTION
### Motivation
- The Library view assumed desktop sidebar layouts and produced poor mobile UX with misplaced filters and cramped touch targets. 
- The intent is to make the Library a touch-first, vertical-screen experience where filters and cards are organized for thumb reach and quick scanning.

### Description
- Introduced a reusable `useMediaQuery` hook and a `mobileFiltersOpen` state to detect viewport changes and toggle mobile filter visibility, located in `frontend/src/main.tsx`. 
- Reworked the `Library` component to preserve the sticky channel sidebar on desktop while providing a mobile summary bar, segmented grid/list toggle, horizontal channel chip scroller, collapsible filter block, and a one-tap `resetFilters` action. 
- Improved card ergonomics by grouping actions under `library-card-actions` and making touch targets stack and expand on narrow screens. 
- Added CSS rules for `.library-mobile-summary`, `.library-toolbar-search`, `.channel-filter-mobile`, `.channel-chip-scroll`, `.library-view-toggle`, and responsive behaviors in `frontend/src/styles.css`.

### Testing
- Ran `npm --prefix frontend run build` which completed successfully. 
- Installed Playwright browsers with `npx playwright install chromium` (download succeeded), but automated screenshot preview using Playwright failed due to a missing system library `libatk-1.0.so.0` in the container environment. 
- No unit test suite changes were required for this UI work and no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f05855370883318909fdd2c6d0ba86)